### PR TITLE
IBX-1694: Rebranded dependency injection container service tags

### DIFF
--- a/src/bundle/Resources/config/views.yaml
+++ b/src/bundle/Resources/config/views.yaml
@@ -3,7 +3,7 @@ services:
         arguments:
             $matcherFactory: '@ibexa.platform.user.view.search.matcher_factory.dynamically_configured'
         tags:
-            - { name: ezpublish.view_provider, type: Ibexa\Search\View\SearchView, priority: 10 }
+            - { name: ibexa.view.provider, type: Ibexa\Search\View\SearchView, priority: 10 }
 
     ibexa.platform.view.search.matcher_factory:
         class: Ibexa\Bundle\Core\Matcher\ServiceAwareMatcherFactory
@@ -38,4 +38,4 @@ services:
             $pagerSearchContentToDataMapper: '@Ibexa\Search\Mapper\PagerSearchContentToDataMapper'
             $searchQueryType: '@Ibexa\Search\QueryType\SearchQueryType'
         tags:
-            - { name: ibexa.view_builder }
+            - { name: ibexa.view.builder }


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-1694](https://issues.ibexa.co/browse/IBX-1694)
| **Type**                                   | feature
| **Target Ibexa version** | `v4.0`
| **BC breaks**                          | yes, requires ibexa/compatibility-layer#12

In this Pull Request we rename Ibexa's dependency injection container service tags according to the map provided by ibexa/compatibility-layer#12 as a part of the rebranding process. Backward compatibility for old service tags is provided by ibexa/compatibility-layer#12.

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [ ] Provided automated test coverage.
- [x] Asked for a review
