### PR TITLE
IBX-6413: Added autocomplete configuration

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,8 @@
         "ibexa/doctrine-schema": "~4.6.x-dev",
         "phpstan/phpstan": "^1.10",
         "phpstan/phpstan-phpunit": "^1.3",
-        "phpstan/phpstan-symfony": "^1.3"
+        "phpstan/phpstan-symfony": "^1.3",
+        "matthiasnoback/symfony-dependency-injection-test": "^4.3"
     },
     "scripts": {
         "fix-cs": "php-cs-fixer fix --config=.php-cs-fixer.php --show-progress=dots",

--- a/src/bundle/DependencyInjection/Configuration/Parser/SiteAccessAware/Autocomplete.php
+++ b/src/bundle/DependencyInjection/Configuration/Parser/SiteAccessAware/Autocomplete.php
@@ -1,0 +1,102 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Bundle\Search\DependencyInjection\Configuration\Parser\SiteAccessAware;
+
+use Ibexa\Bundle\Core\DependencyInjection\Configuration\AbstractParser;
+use Ibexa\Bundle\Core\DependencyInjection\Configuration\SiteAccessAware\ContextualizerInterface;
+use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
+use Symfony\Component\Config\Definition\Builder\NodeBuilder;
+use Symfony\Component\Config\Definition\Builder\TreeBuilder;
+
+/**
+ * Configuration parser for search.
+ *
+ * @Example configuration:
+ *
+ * ```yaml
+ * ibexa:
+ *   system:
+ *      default: # configuration per siteaccess or siteaccess group
+ *          search:
+ *              autocomplete:
+ *                  min_search_test_length: 3
+ *                  result_limit: 5
+ * ```
+ */
+class Autocomplete extends AbstractParser
+{
+    /**
+     * @param array<string, mixed> $scopeSettings
+     */
+    public function mapConfig(
+        array &$scopeSettings,
+        $currentScope,
+        ContextualizerInterface $contextualizer
+    ): void {
+        if (empty($scopeSettings['search'])) {
+            return;
+        }
+
+        $settings = $scopeSettings['search'];
+
+        $this->addAutocompleteParameters($settings, $currentScope, $contextualizer);
+    }
+
+    public function addSemanticConfig(NodeBuilder $nodeBuilder): void
+    {
+        $rootProductCatalogNode = $nodeBuilder->arrayNode('search');
+        $rootProductCatalogNode->append($this->addAutocompleteConfiguration());
+    }
+
+    /**
+     * @param array<string, mixed> $settings
+     */
+    private function addAutocompleteParameters(
+        $settings,
+        string $currentScope,
+        ContextualizerInterface $contextualizer
+    ): void {
+        if (isset($settings['autocomplete']['min_search_test_length'])) {
+            $contextualizer->setContextualParameter(
+                'autocomplete.min_search_test_length',
+                $currentScope,
+                $settings['autocomplete']['min_search_test_length'],
+            );
+        }
+        if (isset($settings['catalogs']['result_limit'])) {
+            $contextualizer->setContextualParameter(
+                'autocomplete.result_limit',
+                $currentScope,
+                $settings['catalogs']['result_limit'],
+            );
+        }
+    }
+
+    private function addAutocompleteConfiguration(): ArrayNodeDefinition
+    {
+        $treeBuilder = new TreeBuilder('autocomplete');
+        $node = $treeBuilder->getRootNode();
+
+        $node
+            ->children()
+                ->integerNode('min_search_test_length')
+                    ->isRequired()
+                    ->defaultValue(3)
+                    ->min(3)
+                ->end()
+                ->integerNode('result_limit')
+                    ->isRequired()
+                    ->defaultValue(5)
+                    ->min(5)
+                ->end()
+            ->end();
+
+        return $node;
+    }
+}

--- a/src/bundle/DependencyInjection/Configuration/Parser/SiteAccessAware/AutocompleteParser.php
+++ b/src/bundle/DependencyInjection/Configuration/Parser/SiteAccessAware/AutocompleteParser.php
@@ -29,7 +29,7 @@ use Symfony\Component\Config\Definition\Builder\TreeBuilder;
  *                  result_limit: 5
  * ```
  */
-class Autocomplete extends AbstractParser
+final class AutocompleteParser extends AbstractParser
 {
     /**
      * @param array<string, mixed> $scopeSettings
@@ -62,19 +62,18 @@ class Autocomplete extends AbstractParser
         string $currentScope,
         ContextualizerInterface $contextualizer
     ): void {
-        if (isset($settings['autocomplete']['min_search_test_length'])) {
-            $contextualizer->setContextualParameter(
-                'autocomplete.min_search_test_length',
-                $currentScope,
-                $settings['autocomplete']['min_search_test_length'],
-            );
-        }
-        if (isset($settings['catalogs']['result_limit'])) {
-            $contextualizer->setContextualParameter(
-                'autocomplete.result_limit',
-                $currentScope,
-                $settings['catalogs']['result_limit'],
-            );
+        $names = [
+            'min_search_test_length',
+            'result_limit',
+        ];
+        foreach ($names as $name) {
+            if (isset($settings['autocomplete'][$name])) {
+                $contextualizer->setContextualParameter(
+                    'search.autocomplete.' . $name,
+                    $currentScope,
+                    $settings['autocomplete'][$name]
+                );
+            }
         }
     }
 

--- a/src/bundle/IbexaSearchBundle.php
+++ b/src/bundle/IbexaSearchBundle.php
@@ -8,6 +8,7 @@ namespace Ibexa\Bundle\Search;
 
 use Ibexa\Bundle\Search\DependencyInjection\Configuration\Parser\Search;
 use Ibexa\Bundle\Search\DependencyInjection\Configuration\Parser\SearchView;
+use Ibexa\Bundle\Search\DependencyInjection\Configuration\Parser\SiteAccessAware\Autocomplete;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
@@ -21,6 +22,7 @@ class IbexaSearchBundle extends Bundle
         $core->addDefaultSettings(__DIR__ . '/Resources/config', ['default_settings.yaml']);
         $core->addConfigParser(new Search());
         $core->addConfigParser(new SearchView());
+        $core->addConfigParser(new Autocomplete());
     }
 }
 

--- a/src/bundle/IbexaSearchBundle.php
+++ b/src/bundle/IbexaSearchBundle.php
@@ -8,7 +8,7 @@ namespace Ibexa\Bundle\Search;
 
 use Ibexa\Bundle\Search\DependencyInjection\Configuration\Parser\Search;
 use Ibexa\Bundle\Search\DependencyInjection\Configuration\Parser\SearchView;
-use Ibexa\Bundle\Search\DependencyInjection\Configuration\Parser\SiteAccessAware\Autocomplete;
+use Ibexa\Bundle\Search\DependencyInjection\Configuration\Parser\SiteAccessAware\AutocompleteParser;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
@@ -22,7 +22,7 @@ class IbexaSearchBundle extends Bundle
         $core->addDefaultSettings(__DIR__ . '/Resources/config', ['default_settings.yaml']);
         $core->addConfigParser(new Search());
         $core->addConfigParser(new SearchView());
-        $core->addConfigParser(new Autocomplete());
+        $core->addConfigParser(new AutocompleteParser());
     }
 }
 

--- a/tests/bundle/DependencyInjection/Cofniguration/Parser/SiteAccessAware/AutocompleteParserTest.php
+++ b/tests/bundle/DependencyInjection/Cofniguration/Parser/SiteAccessAware/AutocompleteParserTest.php
@@ -1,0 +1,102 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Tests\Bundle\Search\DependencyInjection\Cofniguration\Parser\SiteAccessAware;
+
+use Exception;
+use Ibexa\Bundle\Core\DependencyInjection\IbexaCoreExtension;
+use Ibexa\Bundle\Search\DependencyInjection\Configuration\Parser\SiteAccessAware\AutocompleteParser;
+use Ibexa\Core\MVC\Exception\ParameterNotFoundException;
+use Ibexa\Tests\Bundle\Core\DependencyInjection\Configuration\Parser\AbstractParserTestCase;
+
+/**
+ * @covers \Ibexa\Bundle\Search\DependencyInjection\Configuration\Parser\SiteAccessAware\AutocompleteParser
+ */
+final class AutocompleteParserTest extends AbstractParserTestCase
+{
+    protected function getContainerExtensions(): array
+    {
+        return [
+            new IbexaCoreExtension([
+                new AutocompleteParser(),
+            ]),
+        ];
+    }
+
+    /**
+     * @dataProvider dataProviderForTestSettings
+     *
+     * @param array<string,mixed> $config
+     * @param array<string,mixed> $expected
+     * @param array<string> $expectedNotSet
+     */
+    public function testSettings(array $config, array $expected, array $expectedNotSet = []): void
+    {
+        $this->load([
+            'system' => [
+                'ibexa_demo_site' => $config,
+            ],
+        ]);
+
+        foreach ($expected as $key => $val) {
+            $this->assertConfigResolverParameterValue($key, $val, 'ibexa_demo_site');
+        }
+
+        foreach ($expectedNotSet as $key) {
+            $this->assertConfigResolverParameterIsNotSet($key, 'ibexa_demo_site');
+        }
+    }
+
+    /**
+     * @phpstan-return iterable<
+     *     string,
+     *     array{
+     *         array<string, mixed>,
+     *         array<string, mixed>,
+     *         2?: array<string>,
+     *     },
+     * >
+     */
+    public function dataProviderForTestSettings(): iterable
+    {
+        yield 'empty configuration' => [
+            [],
+            [],
+            [
+                'search.autocomplete.min_search_test_length',
+                'search.autocomplete.result_limit',
+            ],
+        ];
+
+        yield 'autocomplete' => [
+            [
+                'search' => [
+                    'autocomplete' => [
+                        'min_search_test_length' => 10,
+                        'result_limit' => 10,
+                    ],
+                ],
+            ],
+            [
+                'search.autocomplete.min_search_test_length' => 10,
+                'search.autocomplete.result_limit' => 10,
+            ],
+        ];
+    }
+
+    private function assertConfigResolverParameterIsNotSet(string $parameterName, ?string $scope = null): void
+    {
+        $chainConfigResolver = $this->getConfigResolver();
+        try {
+            $chainConfigResolver->getParameter($parameterName, 'ibexa.site_access.config', $scope);
+            self::fail(sprintf('Parameter "%s" should not exist in scope "%s"', $parameterName, $scope));
+        } catch (Exception $e) {
+            self::assertInstanceOf(ParameterNotFoundException::class, $e);
+        }
+    }
+}


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       |  [IBX-6413](https://issues.ibexa.co/browse/IBX-6413) 
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | yes
| License       | [GPL-2.0](https://github.com/ibexa/search/blob/main/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


This PR provides additional configuration for the search autocomplete feature.


```yaml
  ibexa:
    system:
       default: # configuration per siteaccess or siteaccess group
           search:
               autocomplete:
                   min_search_test_length: 3
                   result_limit: 5
```


#### Checklist:
- [x] Implement tests
- [x] Coding standards (`$ composer fix-cs`)
