### PR TITLE
IBX-6338: Fix typo In sort definition

### DIFF
--- a/src/bundle/Form/Type/SearchType.php
+++ b/src/bundle/Form/Type/SearchType.php
@@ -83,7 +83,7 @@ final class SearchType extends AbstractType
 
         $builder->add(
             'sort',
-            SortingDefintionChoiceType::class,
+            SortingDefinitionChoiceType::class,
             [
                 'property_path' => 'sortingDefinition',
             ]

--- a/src/bundle/Form/Type/SortingDefinitionChoiceType.php
+++ b/src/bundle/Form/Type/SortingDefinitionChoiceType.php
@@ -14,7 +14,7 @@ use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
-final class SortingDefintionChoiceType extends AbstractType
+final class SortingDefinitionChoiceType extends AbstractType
 {
     private SortingDefinitionRegistryInterface $sortingDefinitionRegistry;
 

--- a/src/bundle/Resources/config/forms.yaml
+++ b/src/bundle/Resources/config/forms.yaml
@@ -41,11 +41,11 @@ services:
         tags:
             - { name: form.type, alias: Ibexa\Bundle\Search\Form\Type\SectionChoiceType }
 
-    Ibexa\Bundle\Search\Form\Type\SortingDefintionChoiceType:
+    Ibexa\Bundle\Search\Form\Type\SortingDefinitionChoiceType:
         arguments:
             $sortingDefinitionRegistry: '@Ibexa\Contracts\Search\SortingDefinition\SortingDefinitionRegistryInterface'
         tags:
-            - { name: form.type, alias: Ibexa\Bundle\Search\Form\Type\SortingDefintionChoiceType }
+            - { name: form.type, alias: Ibexa\Bundle\Search\Form\Type\SortingDefinitionChoiceType }
 
     Ibexa\Bundle\Search\Form\Type\SearchUsersType:
         arguments:

--- a/src/bundle/Resources/config/sorting_definitions.yaml
+++ b/src/bundle/Resources/config/sorting_definitions.yaml
@@ -4,7 +4,7 @@ services:
         autowire: true
         public: false
 
-    Ibexa\Search\SortingDefinition\Provider\NameSortingDefintionProvider:
+    Ibexa\Search\SortingDefinition\Provider\NameSortingDefinitionProvider:
         tags:
             -   name: ibexa.search.sorting_definition.provider
 

--- a/src/bundle/Resources/translations/ibexa_search.en.xliff
+++ b/src/bundle/Resources/translations/ibexa_search.en.xliff
@@ -136,10 +136,10 @@
         <target state="new">Sort by name Z-A</target>
         <note>key: sort_definition.name_desc.label</note>
       </trans-unit>
-      <trans-unit id="48c4f8e4803da42f9c8cd166032d872a88f344c1" resname="sort_defintion.relevance.label">
+      <trans-unit id="48c4f8e4803da42f9c8cd166032d872a88f344c1" resname="sort_definition.relevance.label">
         <source>Sort by relevance</source>
         <target state="new">Sort by relevance</target>
-        <note>key: sort_defintion.relevance.label</note>
+        <note>key: sort_definition.relevance.label</note>
       </trans-unit>
     </body>
   </file>

--- a/src/contracts/SortingDefinition/SortingDefinitionProviderInterface.php
+++ b/src/contracts/SortingDefinition/SortingDefinitionProviderInterface.php
@@ -8,7 +8,7 @@ declare(strict_types=1);
 
 namespace Ibexa\Contracts\Search\SortingDefinition;
 
-interface SortingDefintionProviderInterface
+interface SortingDefinitionProviderInterface
 {
     /**
      * @return \Ibexa\Contracts\Search\SortingDefinition\SortingDefinitionInterface[]

--- a/src/lib/SortingDefinition/Provider/DateSortingDefinitionProvider.php
+++ b/src/lib/SortingDefinition/Provider/DateSortingDefinitionProvider.php
@@ -12,12 +12,12 @@ use Ibexa\Contracts\Core\Repository\Values\Content\Query;
 use Ibexa\Contracts\Core\Repository\Values\Content\Query\SortClause\DateModified;
 use Ibexa\Contracts\Core\Repository\Values\Content\Query\SortClause\DatePublished;
 use Ibexa\Contracts\Search\SortingDefinition\SortingDefinition;
-use Ibexa\Contracts\Search\SortingDefinition\SortingDefintionProviderInterface;
+use Ibexa\Contracts\Search\SortingDefinition\SortingDefinitionProviderInterface;
 use JMS\TranslationBundle\Model\Message;
 use JMS\TranslationBundle\Translation\TranslationContainerInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
-final class DateSortingDefinitionProvider implements SortingDefintionProviderInterface, TranslationContainerInterface
+final class DateSortingDefinitionProvider implements SortingDefinitionProviderInterface, TranslationContainerInterface
 {
     private TranslatorInterface $translator;
 

--- a/src/lib/SortingDefinition/Provider/NameSortingDefinitionProvider.php
+++ b/src/lib/SortingDefinition/Provider/NameSortingDefinitionProvider.php
@@ -14,12 +14,12 @@ use Ibexa\Contracts\Core\Repository\Values\Content\Query\SortClause\ContentName;
 use Ibexa\Contracts\Core\Repository\Values\Content\Query\SortClause\ContentTranslatedName;
 use Ibexa\Contracts\Search\SortingDefinition\SortingDefinition;
 use Ibexa\Contracts\Search\SortingDefinition\SortingDefinitionInterface;
-use Ibexa\Contracts\Search\SortingDefinition\SortingDefintionProviderInterface;
+use Ibexa\Contracts\Search\SortingDefinition\SortingDefinitionProviderInterface;
 use JMS\TranslationBundle\Model\Message;
 use JMS\TranslationBundle\Translation\TranslationContainerInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
-final class NameSortingDefintionProvider implements SortingDefintionProviderInterface, TranslationContainerInterface
+final class NameSortingDefinitionProvider implements SortingDefinitionProviderInterface, TranslationContainerInterface
 {
     private RepositoryConfigurationProvider $configurationProvider;
 

--- a/src/lib/SortingDefinition/Provider/NameSortingDefinitionProvider.php
+++ b/src/lib/SortingDefinition/Provider/NameSortingDefinitionProvider.php
@@ -34,12 +34,12 @@ final class NameSortingDefinitionProvider implements SortingDefinitionProviderIn
     public function getSortingDefinitions(): array
     {
         return [
-            $this->createSortingDefintion(200, false),
-            $this->createSortingDefintion(300, true),
+            $this->createSortingDefinition(200, false),
+            $this->createSortingDefinition(300, true),
         ];
     }
 
-    private function createSortingDefintion(int $priority, bool $reverse): SortingDefinitionInterface
+    private function createSortingDefinition(int $priority, bool $reverse): SortingDefinitionInterface
     {
         $identifier = $this->getIdentifier($reverse);
 

--- a/src/lib/SortingDefinition/Provider/RelevanceSortingDefinitionProvider.php
+++ b/src/lib/SortingDefinition/Provider/RelevanceSortingDefinitionProvider.php
@@ -13,10 +13,10 @@ use Ibexa\Contracts\Core\Repository\Values\Content\Query;
 use Ibexa\Contracts\Core\Repository\Values\Content\Query\SortClause\DateModified;
 use Ibexa\Contracts\Core\Repository\Values\Content\Query\SortClause\Score;
 use Ibexa\Contracts\Search\SortingDefinition\SortingDefinition;
-use Ibexa\Contracts\Search\SortingDefinition\SortingDefintionProviderInterface;
+use Ibexa\Contracts\Search\SortingDefinition\SortingDefinitionProviderInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
-final class RelevanceSortingDefinitionProvider implements SortingDefintionProviderInterface
+final class RelevanceSortingDefinitionProvider implements SortingDefinitionProviderInterface
 {
     private SearchService $searchService;
 

--- a/src/lib/SortingDefinition/Provider/RelevanceSortingDefinitionProvider.php
+++ b/src/lib/SortingDefinition/Provider/RelevanceSortingDefinitionProvider.php
@@ -44,7 +44,7 @@ final class RelevanceSortingDefinitionProvider implements SortingDefintionProvid
     {
         return $this->translator->trans(
             /** @Desc("Sort by relevance") */
-            'sort_defintion.relevance.label',
+            'sort_definition.relevance.label',
             [],
             'ibexa_search'
         );

--- a/src/lib/SortingDefinition/SortingDefinitionRegistry.php
+++ b/src/lib/SortingDefinition/SortingDefinitionRegistry.php
@@ -13,14 +13,14 @@ use Ibexa\Contracts\Search\SortingDefinition\SortingDefinitionRegistryInterface;
 
 final class SortingDefinitionRegistry implements SortingDefinitionRegistryInterface
 {
-    /** @var iterable<\Ibexa\Contracts\Search\SortingDefinition\SortingDefintionProviderInterface> */
+    /** @var iterable<\Ibexa\Contracts\Search\SortingDefinition\SortingDefinitionProviderInterface> */
     private iterable $providers;
 
     /** @var \Ibexa\Contracts\Search\SortingDefinition\SortingDefinitionInterface[] */
     private ?array $definitions = null;
 
     /**
-     * @param iterable<\Ibexa\Contracts\Search\SortingDefinition\SortingDefintionProviderInterface> $providers
+     * @param iterable<\Ibexa\Contracts\Search\SortingDefinition\SortingDefinitionProviderInterface> $providers
      */
     public function __construct(iterable $providers)
     {

--- a/tests/lib/SortingDefinition/Provider/NameSortingDefinitionProviderTest.php
+++ b/tests/lib/SortingDefinition/Provider/NameSortingDefinitionProviderTest.php
@@ -13,11 +13,11 @@ use Ibexa\Contracts\Core\Repository\Values\Content\Query;
 use Ibexa\Contracts\Core\Repository\Values\Content\Query\SortClause\ContentName;
 use Ibexa\Contracts\Core\Repository\Values\Content\Query\SortClause\ContentTranslatedName;
 use Ibexa\Contracts\Search\SortingDefinition\SortingDefinition;
-use Ibexa\Search\SortingDefinition\Provider\NameSortingDefintionProvider;
+use Ibexa\Search\SortingDefinition\Provider\NameSortingDefinitionProvider;
 use PHPUnit\Framework\TestCase;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
-final class NameSortingDefintionProviderTest extends TestCase
+final class NameSortingDefinitionProviderTest extends TestCase
 {
     /** @var \Symfony\Contracts\Translation\TranslatorInterface&\PHPUnit\Framework\MockObject\MockObject */
     private TranslatorInterface $translator;
@@ -25,7 +25,7 @@ final class NameSortingDefintionProviderTest extends TestCase
     /** @var \Ibexa\Bundle\Core\ApiLoader\RepositoryConfigurationProvider&\PHPUnit\Framework\MockObject\MockObject */
     private RepositoryConfigurationProvider $configurationProvider;
 
-    private NameSortingDefintionProvider $provider;
+    private NameSortingDefinitionProvider $provider;
 
     protected function setUp(): void
     {
@@ -34,7 +34,7 @@ final class NameSortingDefintionProviderTest extends TestCase
 
         $this->configurationProvider = $this->createMock(RepositoryConfigurationProvider::class);
 
-        $this->provider = new NameSortingDefintionProvider(
+        $this->provider = new NameSortingDefinitionProvider(
             $this->configurationProvider,
             $this->translator
         );

--- a/tests/lib/SortingDefinition/Provider/RelevanceSortingDefinitionProviderTest.php
+++ b/tests/lib/SortingDefinition/Provider/RelevanceSortingDefinitionProviderTest.php
@@ -51,7 +51,7 @@ final class RelevanceSortingDefinitionProviderTest extends TestCase
             [
                 new SortingDefinition(
                     'relevance',
-                    'sort_defintion.relevance.label',
+                    'sort_definition.relevance.label',
                     [
                         new Score(Query::SORT_DESC),
                     ],
@@ -73,7 +73,7 @@ final class RelevanceSortingDefinitionProviderTest extends TestCase
             [
                 new SortingDefinition(
                     'relevance',
-                    'sort_defintion.relevance.label',
+                    'sort_definition.relevance.label',
                     [
                         new DateModified(Query::SORT_DESC),
                     ],

--- a/tests/lib/SortingDefinition/SortingDefinitionRegistryTest.php
+++ b/tests/lib/SortingDefinition/SortingDefinitionRegistryTest.php
@@ -9,7 +9,7 @@ declare(strict_types=1);
 namespace Ibexa\Tests\Search\SortingDefinition;
 
 use Ibexa\Contracts\Search\SortingDefinition\SortingDefinitionInterface;
-use Ibexa\Contracts\Search\SortingDefinition\SortingDefintionProviderInterface;
+use Ibexa\Contracts\Search\SortingDefinition\SortingDefinitionProviderInterface;
 use Ibexa\Search\SortingDefinition\SortingDefinitionRegistry;
 use PHPUnit\Framework\TestCase;
 
@@ -55,9 +55,9 @@ final class SortingDefinitionRegistryTest extends TestCase
     /**
      * @param \Ibexa\Contracts\Search\SortingDefinition\SortingDefinitionInterface[] $definitions
      */
-    private function createProvider(array $definitions): SortingDefintionProviderInterface
+    private function createProvider(array $definitions): SortingDefinitionProviderInterface
     {
-        $provider = $this->createMock(SortingDefintionProviderInterface::class);
+        $provider = $this->createMock(SortingDefinitionProviderInterface::class);
         $provider->method('getSortingDefinitions')->willReturn($definitions);
 
         return $provider;


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       |  [IBX-6338](https://issues.ibexa.co/browse/IBX-6338)
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | yes
| Tests pass?   | yes/no
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ibexa/search/blob/main/LICENSE)


Fix typo from #25
- on several classnames
- on a function name
- in translation namespace `ibexa_search` on a `sort_definition` family member.

#### Checklist:
- [ ] Implement tests
- [ ] Coding standards (`$ composer fix-cs`)
