### PR TITLE
IBX-6338: Do not add SortClause\ContentId if there is sort clauses

### DIFF
--- a/src/lib/QueryType/SearchQueryType.php
+++ b/src/lib/QueryType/SearchQueryType.php
@@ -54,8 +54,10 @@ class SearchQueryType extends OptionsResolverBasedQueryType
             $query->sortClauses = $sortingDefinition->getSortClauses();
         }
 
-        // Search results order MUST BE deterministic
-        $query->sortClauses[] = new ContentId(Query::SORT_ASC);
+        if (empty($query->sortClauses)) {
+            // Search results order MUST BE deterministic
+            $query->sortClauses[] = new ContentId(Query::SORT_ASC);
+        }
 
         if ($this->searchService->supports(SearchService::CAPABILITY_AGGREGATIONS)) {
             $query->aggregations[] = $this->buildContentTypeTermAggregation($parameters);


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       |  [IBX-6338](https://issues.ibexa.co/browse/IBX-6338)
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes/no
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ibexa/search/blob/main/LICENSE)

Following #25, I disagree with the systematic addition of this Content ID sort clause for two distinct reasons:
- In Elasticsearch, max_score is calculated only if _score is the only sort clause. The addition of this sort clause disable max_score, preventing to extend the search with displaying a relevance ratio score/max_score.
- Because of this addition, SortClause/Random can't be added as a SortingDefinition. "As a reviewer, I want to shuffle the results to pick one randomly for review".


<!-- Replace this comment with Pull Request description -->


#### Checklist:
- [ ] Implement tests
- [ ] Coding standards (`$ composer fix-cs`)


[IBX-6338]: https://ibexa.atlassian.net/browse/IBX-6338?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ