### PR TITLE
Fixed translation extraction

### DIFF
--- a/src/bundle/DependencyInjection/Configuration/Parser/SiteAccessAware/SuggestionParser.php
+++ b/src/bundle/DependencyInjection/Configuration/Parser/SiteAccessAware/SuggestionParser.php
@@ -17,7 +17,7 @@ use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 /**
  * Configuration parser for search.
  *
- * @Example configuration:
+ * Example configuration:
  *
  * ```yaml
  * ibexa:

--- a/src/bundle/Resources/translations/ibexa_search.en.xliff
+++ b/src/bundle/Resources/translations/ibexa_search.en.xliff
@@ -136,7 +136,7 @@
         <target state="new">Sort by name Z-A</target>
         <note>key: sort_definition.name_desc.label</note>
       </trans-unit>
-      <trans-unit id="48c4f8e4803da42f9c8cd166032d872a88f344c1" resname="sort_definition.relevance.label">
+      <trans-unit id="93c30dbedf81f260d2906c302f3920c137cca63f" resname="sort_definition.relevance.label">
         <source>Sort by relevance</source>
         <target state="new">Sort by relevance</target>
         <note>key: sort_definition.relevance.label</note>


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       |  N/A
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ibexa/search/blob/main/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

Fixes:
```
In AnnotationException.php line 40:
                                                                                                                                                            
  [Semantical Error] The annotation "@Example" in class Ibexa\Bundle\Search\DependencyInjection\Configuration\Parser\SiteAccessAware\SuggestionParser was   
  never imported. Did you maybe forget to add a "use" statement for this annotation?  
```


#### Checklist:
- [ ] Implement tests
- [x] Coding standards (`$ composer fix-cs`)
