### PR TITLE
IBX-7236: Suggestions only work with entire words

### DIFF
--- a/src/bundle/Controller/SuggestionController.php
+++ b/src/bundle/Controller/SuggestionController.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace Ibexa\Bundle\Search\Controller;
 
+use Ibexa\Contracts\Core\SiteAccess\ConfigResolverInterface;
 use Ibexa\Search\Model\SuggestionQuery;
 use Ibexa\Search\Service\SuggestionService;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
@@ -17,14 +18,23 @@ final class SuggestionController extends AbstractController
 {
     private SuggestionService $suggestionService;
 
+    private ConfigResolverInterface $configResolver;
+
     public function __construct(
-        SuggestionService $suggestionService
+        SuggestionService $suggestionService,
+        ConfigResolverInterface $configResolver
     ) {
         $this->suggestionService = $suggestionService;
+        $this->configResolver = $configResolver;
     }
 
     public function suggestAction(SuggestionQuery $suggestionQuery): JsonResponse
     {
+        $minQueryLength = $this->configResolver->getParameter('search.suggestion.min_query_length');
+        if (strlen($suggestionQuery->getQuery()) < $minQueryLength) {
+            return $this->json([]);
+        }
+
         $result = $this->suggestionService->suggest($suggestionQuery);
 
         return $this->json($result);

--- a/src/bundle/Controller/SuggestionController.php
+++ b/src/bundle/Controller/SuggestionController.php
@@ -31,7 +31,7 @@ final class SuggestionController extends AbstractController
     public function suggestAction(SuggestionQuery $suggestionQuery): JsonResponse
     {
         $minQueryLength = $this->configResolver->getParameter('search.suggestion.min_query_length');
-        if (strlen($suggestionQuery->getQuery()) < $minQueryLength) {
+        if (mb_strlen($suggestionQuery->getQuery()) < $minQueryLength) {
             return $this->json([]);
         }
 

--- a/src/lib/EventDispatcher/EventListener/ContentSuggestionSubscriber.php
+++ b/src/lib/EventDispatcher/EventListener/ContentSuggestionSubscriber.php
@@ -51,7 +51,7 @@ final class ContentSuggestionSubscriber implements EventSubscriberInterface, Log
 
         $query = new Query(
             [
-                'query' => new Query\Criterion\FullText($value . '*'),
+                'query' => new Query\Criterion\FullText('*' . $value . '*'),
                 'limit' => $limit,
             ]
         );

--- a/src/lib/EventDispatcher/EventListener/ContentSuggestionSubscriber.php
+++ b/src/lib/EventDispatcher/EventListener/ContentSuggestionSubscriber.php
@@ -51,7 +51,7 @@ final class ContentSuggestionSubscriber implements EventSubscriberInterface, Log
 
         $query = new Query(
             [
-                'query' => new Query\Criterion\FullText($value),
+                'query' => new Query\Criterion\FullText($value . '*'),
                 'limit' => $limit,
             ]
         );

--- a/src/lib/EventDispatcher/EventListener/ContentSuggestionSubscriber.php
+++ b/src/lib/EventDispatcher/EventListener/ContentSuggestionSubscriber.php
@@ -51,7 +51,7 @@ final class ContentSuggestionSubscriber implements EventSubscriberInterface, Log
 
         $query = new Query(
             [
-                'query' => new Query\Criterion\FullText('*' . $value . '*'),
+                'query' => new Query\Criterion\FullText($value . '*'),
                 'limit' => $limit,
             ]
         );

--- a/src/lib/View/SearchViewFilter.php
+++ b/src/lib/View/SearchViewFilter.php
@@ -93,6 +93,7 @@ class SearchViewFilter implements EventSubscriberInterface
         if (!empty($search['section'])) {
             $section = $this->sectionService->loadSection($search['section']);
         }
+
         if (!empty($search['content_types']) && \is_array($search['content_types'])) {
             foreach ($search['content_types'] as $identifier) {
                 $contentTypes[] = $this->contentTypeService->loadContentTypeByIdentifier($identifier);


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       |  [IBX-7236](https://issues.ibexa.co/browse/IBX-7236) <!-- URLs to JIRA issue(s) (or N/A) -->
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ibexa/search/blob/main/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


This PR fixes:
- an issue with min_query_lenght settings
- an issue with finding only entire words
- related PR https://github.com/ibexa/core/pull/298


#### Checklist:
- [ ] Implement tests
- [x] Coding standards (`$ composer fix-cs`)
