### PR TITLE
IBX-7419: [autcomplete] Add the total number of results to the autocomplete/suggestions endpoint

### DIFF
--- a/src/bundle/Resources/config/services/normalizers.yaml
+++ b/src/bundle/Resources/config/services/normalizers.yaml
@@ -12,6 +12,7 @@ services:
                 - '@Ibexa\Search\Serializer\Normalizer\Suggestion\ContentSuggestionNormalizer'
                 - '@Ibexa\Search\Serializer\Normalizer\Suggestion\LocationNormalizer'
                 - '@Ibexa\Search\Serializer\Normalizer\Suggestion\ParentLocationCollectionNormalizer'
+                - '@Ibexa\Search\Serializer\Normalizer\Suggestion\SuggestionCollectionNormalizer'
             $encoders:
                 - '@serializer.encoder.json'
 
@@ -22,4 +23,7 @@ services:
         autoconfigure: false
 
     Ibexa\Search\Serializer\Normalizer\Suggestion\LocationNormalizer:
+        autoconfigure: false
+
+    Ibexa\Search\Serializer\Normalizer\Suggestion\SuggestionCollectionNormalizer:
         autoconfigure: false

--- a/src/contracts/Model/Suggestion/SuggestionCollection.php
+++ b/src/contracts/Model/Suggestion/SuggestionCollection.php
@@ -18,6 +18,15 @@ use Ibexa\Contracts\Core\Exception\InvalidArgumentException;
  */
 final class SuggestionCollection extends MutableArrayList
 {
+    private int $totalCount;
+
+    public function __construct(array $items = [], int $totalCount = 0)
+    {
+        parent::__construct($items);
+        $this->items = $items;
+        $this->totalCount = $totalCount;
+    }
+
     /**
      * @param mixed $item
      */
@@ -46,5 +55,20 @@ final class SuggestionCollection extends MutableArrayList
     public function truncate(int $count): void
     {
         $this->items = array_slice($this->items, 0, $count);
+    }
+
+    public function increaseTotalCount(int $totalCount): void
+    {
+        $this->totalCount += $totalCount;
+    }
+
+    public function decreaseTotalCount(int $totalCount): void
+    {
+        $this->totalCount -= $totalCount;
+    }
+
+    public function getTotalCount(): int
+    {
+        return $this->totalCount;
     }
 }

--- a/src/lib/EventDispatcher/EventListener/ContentSuggestionSubscriber.php
+++ b/src/lib/EventDispatcher/EventListener/ContentSuggestionSubscriber.php
@@ -67,6 +67,8 @@ final class ContentSuggestionSubscriber implements EventSubscriberInterface, Log
                 }
                 $suggestionCollection->append($contentSuggestion);
             }
+
+            $suggestionCollection->increaseTotalCount($searchResult->totalCount ?? 0);
         } catch (InvalidArgumentException $e) {
             $this->logger->error($e);
         }

--- a/src/lib/Serializer/Normalizer/Suggestion/SuggestionCollectionNormalizer.php
+++ b/src/lib/Serializer/Normalizer/Suggestion/SuggestionCollectionNormalizer.php
@@ -1,0 +1,53 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Search\Serializer\Normalizer\Suggestion;
+
+use Ibexa\Contracts\Search\Model\Suggestion\SuggestionCollection;
+use Symfony\Component\Serializer\Normalizer\CacheableSupportsMethodInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+
+final class SuggestionCollectionNormalizer implements
+    NormalizerInterface,
+    NormalizerAwareInterface,
+    CacheableSupportsMethodInterface
+{
+    use NormalizerAwareTrait;
+
+    /**
+     * @param \Ibexa\Contracts\Search\Model\Suggestion\SuggestionCollection $object
+     * @param array<string, mixed> $context
+     *
+     * @return array<string,mixed>.
+     */
+    public function normalize($object, string $format = null, array $context = []): array
+    {
+        $suggestionCollection = [];
+
+        foreach ($object as $parentLocation) {
+            $suggestionCollection[] = $this->normalizer->normalize($parentLocation, $format, $context);
+        }
+
+        return [
+            'suggestionResults' => $suggestionCollection,
+            'totalCount' => $object->getTotalCount(),
+        ];
+    }
+
+    public function supportsNormalization($data, string $format = null): bool
+    {
+        return $data instanceof SuggestionCollection;
+    }
+
+    public function hasCacheableSupportsMethod(): bool
+    {
+        return true;
+    }
+}

--- a/tests/lib/Serializer/Normalizer/Suggestion/SuggestionCollectionNormalizerTest.php
+++ b/tests/lib/Serializer/Normalizer/Suggestion/SuggestionCollectionNormalizerTest.php
@@ -35,7 +35,7 @@ final class SuggestionCollectionNormalizerTest extends TestCase
         $suggestionCollection->increaseTotalCount(100);
 
         $this->normalizer
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('normalize')
             ->with($suggestionItemMock)
             ->willReturn(['mocked_normalized_data']);

--- a/tests/lib/Serializer/Normalizer/Suggestion/SuggestionCollectionNormalizerTest.php
+++ b/tests/lib/Serializer/Normalizer/Suggestion/SuggestionCollectionNormalizerTest.php
@@ -1,0 +1,53 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Tests\Search\Serializer\Normalizer\Suggestion;
+
+use Ibexa\Contracts\Search\Model\Suggestion\Suggestion;
+use Ibexa\Contracts\Search\Model\Suggestion\SuggestionCollection;
+use Ibexa\Search\Serializer\Normalizer\Suggestion\SuggestionCollectionNormalizer;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+
+final class SuggestionCollectionNormalizerTest extends TestCase
+{
+    /** @var \Symfony\Component\Serializer\Normalizer\NormalizerInterface|\PHPUnit\Framework\MockObject\MockObject */
+    private NormalizerInterface $normalizer;
+
+    private SuggestionCollectionNormalizer $suggestionCollectionNormalizer;
+
+    protected function setUp(): void
+    {
+        $this->normalizer = $this->createMock(NormalizerInterface::class);
+        $this->suggestionCollectionNormalizer = new SuggestionCollectionNormalizer();
+        $this->suggestionCollectionNormalizer->setNormalizer($this->normalizer);
+    }
+
+    public function testNormalize(): void
+    {
+        $suggestionItemMock = $this->createMock(Suggestion::class);
+        $suggestionCollection = new SuggestionCollection([$suggestionItemMock]);
+        $suggestionCollection->increaseTotalCount(100);
+
+        $this->normalizer
+            ->expects($this->once())
+            ->method('normalize')
+            ->with($suggestionItemMock)
+            ->willReturn(['mocked_normalized_data']);
+
+        $expected = [
+            'suggestionResults' => [['mocked_normalized_data']],
+            'totalCount' => 100,
+        ];
+
+        self::assertEquals(
+            $expected,
+            $this->suggestionCollectionNormalizer->normalize($suggestionCollection)
+        );
+    }
+}


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       |  [IBX-7419](https://issues.ibexa.co/browse/IBX-7419) <!-- URLs to JIRA issue(s) (or N/A) -->
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | yes
| License       | [GPL-2.0](https://github.com/ibexa/search/blob/main/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


This PR adds new two properties in the suggestion endpoint, `suggestionResults` and `totalCount`.

`http://127.0.0.1:8000/suggestion?query=ala&limit=1`

```json
{
  "suggestionResults": [
    {
      "contentId": 66,
      "locationId": 67,
      "contentTypeIdentifier": "article",
      "name": "abra ala kadabra",
      "pathString": "2/67",
      "type": "content",
      "parentLocations": [
        {
          "id": 52,
          "locationId": 2,
          "name": "Ibexa Digital Experience Platform"
        },
        { "id": 66, "locationId": 67, "name": "abra ala kadabra" }
      ]
    }
  ],
  "resultsCount": 3
}
```

The capability to adjust the totalCount via an extension point can be achieved through the use of `\Ibexa\Contracts\Search\Model\Suggestion\SuggestionCollection::increaseTotalCount` or 
`\Ibexa\Contracts\Search\Model\Suggestion\SuggestionCollection::decreaseTotalCount`

#### Checklist:
- [x] Implement tests
- [ ] Coding standards (`$ composer fix-cs`)
