### PR TITLE
IBX-7462: Removed "Top Level Nodes" from breadcrumbs in search suggestions

### DIFF
--- a/src/lib/Mapper/SearchHitToContentSuggestionMapper.php
+++ b/src/lib/Mapper/SearchHitToContentSuggestionMapper.php
@@ -17,6 +17,8 @@ use Ibexa\Contracts\Search\Provider\ParentLocationProviderInterface;
 
 final class SearchHitToContentSuggestionMapper implements SearchHitToContentSuggestionMapperInterface
 {
+    private const ROOT_LOCATION_ID = 1;
+
     private ConfigResolverInterface $configResolver;
 
     private ParentLocationProviderInterface $parentLocationProvider;
@@ -49,6 +51,11 @@ final class SearchHitToContentSuggestionMapper implements SearchHitToContentSugg
         $position = array_search($rootLocationId, $parentsLocation, true);
         if ($position !== false) {
             $parentsLocation = array_slice($parentsLocation, (int)$position);
+        }
+
+        if (reset($parentsLocation) === self::ROOT_LOCATION_ID) {
+            // Remove "Top Level Nodes" from suggestion path
+            array_shift($parentsLocation);
         }
 
         $parentLocations = $this->parentLocationProvider->provide($parentsLocation);

--- a/tests/lib/Mapper/SearchHitToContentSuggestionMapperTest.php
+++ b/tests/lib/Mapper/SearchHitToContentSuggestionMapperTest.php
@@ -29,7 +29,51 @@ final class SearchHitToContentSuggestionMapperTest extends TestCase
             $this->getConfigResolverMock()
         );
 
-        $content = new Content([
+        $content = $this->createContentWithLocationPath(['1', '2', '3', '4', '5', '6', '7']);
+
+        $result = $mapper->map(
+            new SearchHit([
+                'valueObject' => $content,
+            ])
+        );
+
+        self::assertInstanceOf(ContentSuggestion::class, $result);
+        self::assertSame($content, $result->getContent());
+        self::assertSame('5/6/7', $result->getPathString());
+        self::assertCount(3, $result->getParentsLocation());
+        self::assertSame('name_eng', $result->getName());
+        self::assertSame(50.0, $result->getScore());
+    }
+
+    public function testMapContentOutsideRootLocation(): void
+    {
+        $mapper = new SearchHitToContentSuggestionMapper(
+            $this->getParentLocationProviderMock(),
+            $this->getConfigResolverMock()
+        );
+
+        $content = $this->createContentWithLocationPath(['1', '2', '3', '4', '6', '7']);
+
+        $result = $mapper->map(
+            new SearchHit([
+                'valueObject' => $content,
+            ])
+        );
+
+        self::assertInstanceOf(ContentSuggestion::class, $result);
+        self::assertSame($content, $result->getContent());
+        self::assertSame('2/3/4/6/7', $result->getPathString());
+        self::assertCount(5, $result->getParentsLocation());
+        self::assertSame('name_eng', $result->getName());
+        self::assertSame(50.0, $result->getScore());
+    }
+
+    /**
+     * @param string[] $path
+     */
+    private function createContentWithLocationPath(array $path): Content
+    {
+        return new Content([
             'id' => 1,
             'contentInfo' => new ContentInfo([
                 'name' => 'name',
@@ -46,7 +90,7 @@ final class SearchHitToContentSuggestionMapperTest extends TestCase
                     'contentTypeId' => 1,
                     'mainLocation' => new Location([
                         'id' => 8,
-                        'path' => ['1', '2', '3', '4', '5', '6', '7'],
+                        'path' => $path,
                     ]),
                 ]),
             ]),
@@ -54,19 +98,6 @@ final class SearchHitToContentSuggestionMapperTest extends TestCase
                 'identifier' => 'content_type_identifier',
             ]),
         ]);
-
-        $result = $mapper->map(
-            new SearchHit([
-                'valueObject' => $content,
-            ])
-        );
-
-        self::assertInstanceOf(ContentSuggestion::class, $result);
-        self::assertSame($content, $result->getContent());
-        self::assertSame('5/6/7', $result->getPathString());
-        self::assertCount(3, $result->getParentsLocation());
-        self::assertSame('name_eng', $result->getName());
-        self::assertSame(50.0, $result->getScore());
     }
 
     /**


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       |  [IBX-7462](https://issues.ibexa.co/browse/IBX-7462) 
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ibexa/search/blob/main/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

![image](https://github.com/ibexa/search/assets/211967/b970438e-eb28-4d5b-a730-6fbe3b2e0859)

#### Checklist:
- [X] Implement tests
- [X] Coding standards (`$ composer fix-cs`)
