### PR TITLE
IBX-6583: Added "Choose an option" placeholder for Language selector

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -49,5 +49,8 @@
         "branch-alias": {
             "dev-main": "4.5.x-dev"
         }
+    },
+    "config": {
+        "allow-plugins": false
     }
 }

--- a/src/bundle/Form/Type/SearchType.php
+++ b/src/bundle/Form/Type/SearchType.php
@@ -64,7 +64,7 @@ final class SearchType extends AbstractType
                     'required' => false,
                     'multiple' => false,
                     'expanded' => false,
-                    'placeholder' => false,
+                    'placeholder' => /** @Desc("Choose an option") */ 'search.language.any',
                 ]
             )
             ->add('subtree', HiddenType::class, [

--- a/src/bundle/Resources/translations/search.en.xliff
+++ b/src/bundle/Resources/translations/search.en.xliff
@@ -31,6 +31,11 @@
         <target>Search results (%total%)</target>
         <note>key: search.header</note>
       </trans-unit>
+      <trans-unit id="56906249002c19e57c1992ba0d25f86bbc7120c0" resname="search.language.any">
+        <source>Choose an option</source>
+        <target state="new">Choose an option</target>
+        <note>key: search.language.any</note>
+      </trans-unit>
       <trans-unit id="c2e9df867c114a94918c00f775d3a54d24358dfa" resname="search.last.modified">
         <source>Last modified</source>
         <target>Last modified</target>


### PR DESCRIPTION
| Question                 | Answer                                              |
|--------------------------|-----------------------------------------------------|
| **JIRA issue**           | [IBX-6583](https://issues.ibexa.co/browse/IBX-6583) |
| **Type**                 | bug                             |
| **Target Ibexa version** | `v4.5`+ |
| **BC breaks**            | no                                              |

When global search input is used from anywhere in the system other than `/admin/search` page, no language is passed and search shows results for all found languages. However, there's the language selector form field suggesting that the first language from the list was selected (usually English). Visible only when there's more than one language defined in the system.

Therefore specification was updated to include an empty state for that form field saying "Choose an option".

![image](https://github.com/ibexa/search/assets/7099219/b34196cc-0ba6-45ed-afe7-6f8474c2870d)


#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [ ] Provided automated test coverage.
- [x] Checked that target branch is set correctly (main for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [ ] Asked for a review.