### PR TITLE
IBX-8139: Dropped class_alias BC layer statements from all classes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,19 +10,14 @@
         "psr-4": {
             "Ibexa\\Search\\": "src/lib/",
             "Ibexa\\Bundle\\Search\\": "src/bundle/",
-            "Ibexa\\Contracts\\Search\\": "src/contracts/",
-            "Ibexa\\Platform\\Bundle\\Search\\": "src/bundle/",
-            "Ibexa\\Platform\\Search\\": "src/lib/"
+            "Ibexa\\Contracts\\Search\\": "src/contracts/"
         }
     },
     "autoload-dev": {
         "psr-4": {
             "Ibexa\\Tests\\Bundle\\Search\\": "tests/bundle/",
             "Ibexa\\Tests\\Contracts\\Search\\": "tests/contracts/",
-            "Ibexa\\Tests\\Search\\": "tests/lib/",
-            "Ibexa\\Platform\\Tests\\Contracts\\Search\\": "tests/contracts/",
-            "Ibexa\\Platform\\Tests\\Bundle\\Search\\": "tests/bundle/",
-            "Ibexa\\Platform\\Tests\\Search\\": "tests/lib/"
+            "Ibexa\\Tests\\Search\\": "tests/lib/"
         }
     },
     "require": {

--- a/src/bundle/Controller/SearchController.php
+++ b/src/bundle/Controller/SearchController.php
@@ -18,5 +18,3 @@ class SearchController extends AbstractController
         return $view;
     }
 }
-
-class_alias(SearchController::class, 'Ibexa\Platform\Bundle\Search\Controller\SearchController');

--- a/src/bundle/DependencyInjection/Configuration/Parser/Search.php
+++ b/src/bundle/DependencyInjection/Configuration/Parser/Search.php
@@ -54,5 +54,3 @@ class Search extends AbstractParser
         }
     }
 }
-
-class_alias(Search::class, 'Ibexa\Platform\Bundle\Search\DependencyInjection\Configuration\Parser\Search');

--- a/src/bundle/DependencyInjection/Configuration/Parser/SearchView.php
+++ b/src/bundle/DependencyInjection/Configuration/Parser/SearchView.php
@@ -15,5 +15,3 @@ class SearchView extends View
     public const NODE_KEY = 'search_view';
     public const INFO = 'Template for displaying main search form and results';
 }
-
-class_alias(SearchView::class, 'Ibexa\Platform\Bundle\Search\DependencyInjection\Configuration\Parser\SearchView');

--- a/src/bundle/DependencyInjection/IbexaSearchExtension.php
+++ b/src/bundle/DependencyInjection/IbexaSearchExtension.php
@@ -53,5 +53,3 @@ class IbexaSearchExtension extends Extension implements PrependExtensionInterfac
         ]);
     }
 }
-
-class_alias(IbexaSearchExtension::class, 'Ibexa\Platform\Bundle\Search\DependencyInjection\IbexaPlatformSearchExtension');

--- a/src/bundle/Form/ChoiceLoader/ConfiguredLanguagesChoiceLoader.php
+++ b/src/bundle/Form/ChoiceLoader/ConfiguredLanguagesChoiceLoader.php
@@ -104,5 +104,3 @@ class ConfiguredLanguagesChoiceLoader implements ChoiceLoaderInterface
         return array_merge($orderedLanguages, array_values($languagesAssoc));
     }
 }
-
-class_alias(ConfiguredLanguagesChoiceLoader::class, 'Ibexa\Platform\Bundle\Search\Form\ChoiceLoader\ConfiguredLanguagesChoiceLoader');

--- a/src/bundle/Form/ChoiceLoader/ContentTypeChoiceLoader.php
+++ b/src/bundle/Form/ChoiceLoader/ContentTypeChoiceLoader.php
@@ -95,5 +95,3 @@ class ContentTypeChoiceLoader implements ChoiceLoaderInterface
         return $this->loadChoiceList($value)->getValuesForChoices($choices);
     }
 }
-
-class_alias(ContentTypeChoiceLoader::class, 'Ibexa\Platform\Bundle\Search\Form\ChoiceLoader\ContentTypeChoiceLoader');

--- a/src/bundle/Form/Data/SearchData.php
+++ b/src/bundle/Form/Data/SearchData.php
@@ -231,5 +231,3 @@ class SearchData
             null !== $subtree;
     }
 }
-
-class_alias(SearchData::class, 'Ibexa\Platform\Bundle\Search\Form\Data\SearchData');

--- a/src/bundle/Form/Data/SearchUsersData.php
+++ b/src/bundle/Form/Data/SearchUsersData.php
@@ -42,5 +42,3 @@ class SearchUsersData
         $this->possibleUsers = $possibleUsers;
     }
 }
-
-class_alias(SearchUsersData::class, 'Ibexa\Platform\Bundle\Search\Form\Data\SearchUsersData');

--- a/src/bundle/Form/DataTransformer/DateIntervalTransformer.php
+++ b/src/bundle/Form/DataTransformer/DateIntervalTransformer.php
@@ -54,5 +54,3 @@ class DateIntervalTransformer implements DataTransformerInterface
         ];
     }
 }
-
-class_alias(DateIntervalTransformer::class, 'Ibexa\Platform\Bundle\Search\Form\DataTransformer\DateIntervalTransformer');

--- a/src/bundle/Form/DataTransformer/UserTransformer.php
+++ b/src/bundle/Form/DataTransformer/UserTransformer.php
@@ -80,5 +80,3 @@ class UserTransformer implements DataTransformerInterface
         }
     }
 }
-
-class_alias(UserTransformer::class, 'Ibexa\Platform\Bundle\Search\Form\DataTransformer\UserTransformer');

--- a/src/bundle/Form/DataTransformer/UsersTransformer.php
+++ b/src/bundle/Form/DataTransformer/UsersTransformer.php
@@ -93,5 +93,3 @@ class UsersTransformer implements DataTransformerInterface
         );
     }
 }
-
-class_alias(UsersTransformer::class, 'Ibexa\Platform\Bundle\Search\Form\DataTransformer\UsersTransformer');

--- a/src/bundle/Form/Type/ContentTypeChoiceType.php
+++ b/src/bundle/Form/Type/ContentTypeChoiceType.php
@@ -46,5 +46,3 @@ class ContentTypeChoiceType extends AbstractType
             ]);
     }
 }
-
-class_alias(ContentTypeChoiceType::class, 'Ibexa\Platform\Bundle\Search\Form\Type\ContentTypeChoiceType');

--- a/src/bundle/Form/Type/DateIntervalType.php
+++ b/src/bundle/Form/Type/DateIntervalType.php
@@ -34,5 +34,3 @@ class DateIntervalType extends AbstractType
             ->addModelTransformer(new DateIntervalTransformer());
     }
 }
-
-class_alias(DateIntervalType::class, 'Ibexa\Platform\Bundle\Search\Form\Type\DateIntervalType');

--- a/src/bundle/Form/Type/LanguageChoiceType.php
+++ b/src/bundle/Form/Type/LanguageChoiceType.php
@@ -39,5 +39,3 @@ class LanguageChoiceType extends AbstractType
             ]);
     }
 }
-
-class_alias(LanguageChoiceType::class, 'Ibexa\Platform\Bundle\Search\Form\Type\LanguageChoiceType');

--- a/src/bundle/Form/Type/SearchType.php
+++ b/src/bundle/Form/Type/SearchType.php
@@ -103,5 +103,3 @@ final class SearchType extends AbstractType
         ]);
     }
 }
-
-class_alias(SearchType::class, 'Ibexa\Platform\Bundle\Search\Form\Type\SearchType');

--- a/src/bundle/Form/Type/SearchUsersType.php
+++ b/src/bundle/Form/Type/SearchUsersType.php
@@ -61,5 +61,3 @@ class SearchUsersType extends AbstractType
         ]);
     }
 }
-
-class_alias(SearchUsersType::class, 'Ibexa\Platform\Bundle\Search\Form\Type\SearchUsersType');

--- a/src/bundle/Form/Type/SectionChoiceType.php
+++ b/src/bundle/Form/Type/SectionChoiceType.php
@@ -48,5 +48,3 @@ class SectionChoiceType extends AbstractType
         return ChoiceType::class;
     }
 }
-
-class_alias(SectionChoiceType::class, 'Ibexa\Platform\Bundle\Search\Form\Type\SectionChoiceType');

--- a/src/bundle/Form/Type/UserType.php
+++ b/src/bundle/Form/Type/UserType.php
@@ -34,5 +34,3 @@ class UserType extends AbstractType
         return HiddenType::class;
     }
 }
-
-class_alias(UserType::class, 'Ibexa\Platform\Bundle\Search\Form\Type\UserType');

--- a/src/bundle/IbexaSearchBundle.php
+++ b/src/bundle/IbexaSearchBundle.php
@@ -26,5 +26,3 @@ class IbexaSearchBundle extends Bundle
         $core->addConfigParser(new SuggestionParser());
     }
 }
-
-class_alias(IbexaSearchBundle::class, 'Ibexa\Platform\Bundle\Search\IbexaPlatformSearchBundle');

--- a/src/lib/Mapper/PagerSearchContentToDataMapper.php
+++ b/src/lib/Mapper/PagerSearchContentToDataMapper.php
@@ -162,5 +162,3 @@ class PagerSearchContentToDataMapper
         }
     }
 }
-
-class_alias(PagerSearchContentToDataMapper::class, 'Ibexa\Platform\Search\Mapper\PagerSearchContentToDataMapper');

--- a/src/lib/QueryType/SearchQueryType.php
+++ b/src/lib/QueryType/SearchQueryType.php
@@ -176,5 +176,3 @@ class SearchQueryType extends OptionsResolverBasedQueryType
         return $aggregation;
     }
 }
-
-class_alias(SearchQueryType::class, 'Ibexa\Platform\Search\QueryType\SearchQueryType');

--- a/src/lib/View/SearchView.php
+++ b/src/lib/View/SearchView.php
@@ -13,5 +13,3 @@ use Ibexa\Core\MVC\Symfony\View\BaseView;
 class SearchView extends BaseView
 {
 }
-
-class_alias(SearchView::class, 'Ibexa\Platform\Search\View\SearchView');

--- a/src/lib/View/SearchViewBuilder.php
+++ b/src/lib/View/SearchViewBuilder.php
@@ -106,5 +106,3 @@ class SearchViewBuilder implements ViewBuilder
         ];
     }
 }
-
-class_alias(SearchViewBuilder::class, 'Ibexa\Platform\Search\View\SearchViewBuilder');

--- a/src/lib/View/SearchViewFilter.php
+++ b/src/lib/View/SearchViewFilter.php
@@ -126,5 +126,3 @@ class SearchViewFilter implements EventSubscriberInterface
         ]);
     }
 }
-
-class_alias(SearchViewFilter::class, 'Ibexa\Platform\Search\View\SearchViewFilter');

--- a/src/lib/View/SearchViewProvider.php
+++ b/src/lib/View/SearchViewProvider.php
@@ -51,5 +51,3 @@ class SearchViewProvider implements ViewProvider
         return $view;
     }
 }
-
-class_alias(SearchViewProvider::class, 'Ibexa\Platform\Search\View\SearchViewProvider');


### PR DESCRIPTION
| :ticket: Issue | IBX-8139 |
|----------------|-----------|

#### Description:

Dropped `class_alias` BC layer statements from all classes using https://github.com/ibexa/rector/pull/2

#### For QA:

No QA needed

#### Documentation:

Document that our BC layer has been dropped
