### PR TITLE
IBX-8119: Upgraded minimum PHP version to 8.3

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,13 +10,13 @@ on:
 jobs:
     cs-fix:
         name: Run code style check
-        runs-on: "ubuntu-20.04"
+        runs-on: "ubuntu-22.04"
         strategy:
             matrix:
                 php:
-                    - '8.0'
+                    - '8.3'
         steps:
-            - uses: actions/checkout@v2
+            - uses: actions/checkout@v4
 
             - name: Setup PHP Action
               uses: shivammathur/setup-php@v2
@@ -26,9 +26,9 @@ jobs:
                   extensions: 'pdo_sqlite, gd'
                   tools: cs2pr
 
-            - uses: "ramsey/composer-install@v1"
+            - uses: ramsey/composer-install@v3
               with:
-                  dependency-versions: "highest"
+                  dependency-versions: highest
 
             - name: Run code style check
               run: composer run-script check-cs -- --format=checkstyle | cs2pr
@@ -38,19 +38,17 @@ jobs:
 
     tests:
         name: Unit tests
-        runs-on: "ubuntu-20.04"
+        runs-on: "ubuntu-22.04"
         timeout-minutes: 15
 
         strategy:
             fail-fast: false
             matrix:
                 php:
-                    - '7.4'
-                    - '8.0'
-                    - '8.1'
+                    - '8.3'
 
         steps:
-            - uses: actions/checkout@v2
+            - uses: actions/checkout@v4
 
             - name: Setup PHP Action
               uses: shivammathur/setup-php@v2
@@ -60,9 +58,9 @@ jobs:
                   extensions: pdo_sqlite, gd
                   tools: cs2pr
 
-            - uses: "ramsey/composer-install@v1"
+            - uses: ramsey/composer-install@v3
               with:
-                  dependency-versions: "highest"
+                  dependency-versions: highest
 
             - name: Setup problem matchers for PHPUnit
               run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"

--- a/composer.json
+++ b/composer.json
@@ -26,26 +26,26 @@
         }
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": " >=8.3",
         "ibexa/core": "~5.0.x-dev",
-        "symfony/dependency-injection": "^5.0",
-        "symfony/http-kernel": "^5.0",
-        "symfony/http-foundation": "^5.0",
-        "symfony/config": "^5.0",
-        "symfony/form": "^5.0",
-        "symfony/event-dispatcher": "^5.0",
         "pagerfanta/pagerfanta": "^2.1",
+        "symfony/config": "^5.0",
+        "symfony/dependency-injection": "^5.0",
+        "symfony/event-dispatcher": "^5.0",
+        "symfony/form": "^5.0",
+        "symfony/http-foundation": "^5.0",
+        "symfony/http-kernel": "^5.0",
         "symfony/serializer": "^5.4"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.6",
         "friendsofphp/php-cs-fixer": "^3.0",
         "ibexa/code-style": "^1.0",
         "ibexa/doctrine-schema": "~5.0.x-dev",
+        "matthiasnoback/symfony-dependency-injection-test": "^4.3",
         "phpstan/phpstan": "^1.10",
         "phpstan/phpstan-phpunit": "^1.3",
         "phpstan/phpstan-symfony": "^1.3",
-        "matthiasnoback/symfony-dependency-injection-test": "^4.3"
+        "phpunit/phpunit": "^9.6"
     },
     "scripts": {
         "fix-cs": "php-cs-fixer fix --config=.php-cs-fixer.php --show-progress=dots",
@@ -59,6 +59,7 @@
         }
     },
     "config": {
-        "allow-plugins": false
+        "allow-plugins": false,
+        "sort-packages": true
     }
 }

--- a/src/lib/Mapper/PagerSearchContentToDataMapper.php
+++ b/src/lib/Mapper/PagerSearchContentToDataMapper.php
@@ -144,9 +144,11 @@ class PagerSearchContentToDataMapper
     protected function setTranslatedContentTypesNames(array &$data, array $contentTypeIds): void
     {
         // load list of content types with proper translated names
-        $contentTypes = $this->contentTypeService->loadContentTypeList(
-            array_unique($contentTypeIds),
-            $this->userLanguagePreferenceProvider->getPreferredLanguages()
+        $contentTypes = iterator_to_array(
+            $this->contentTypeService->loadContentTypeList(
+                array_unique($contentTypeIds),
+                $this->userLanguagePreferenceProvider->getPreferredLanguages()
+            )
         );
 
         foreach ($data as $idx => $item) {


### PR DESCRIPTION
| :ticket: Issue | IBX-8119 |
|----------------|-----------|
| Blocks | CI of #46 |

#### Description:
Seems there was never a PR created from this branch. Bumping PHP to 8.3

It includes:
- changing `composer.json` requirements
- sorting `composer.json` packages
- updating GHA CI jobs config
- fixing issue with iterables used as arrays which is recently reported by PHPStan. This time fix is simple so I've applied it right away instead of adding the issue to the baseline.
