### PR TITLE
IBX-8394: Used new RepositoryConfigurationProviderInterface contract

### DIFF
--- a/src/lib/SortingDefinition/Provider/NameSortingDefinitionProvider.php
+++ b/src/lib/SortingDefinition/Provider/NameSortingDefinitionProvider.php
@@ -8,7 +8,7 @@ declare(strict_types=1);
 
 namespace Ibexa\Search\SortingDefinition\Provider;
 
-use Ibexa\Bundle\Core\ApiLoader\RepositoryConfigurationProvider;
+use Ibexa\Contracts\Core\Container\ApiLoader\RepositoryConfigurationProviderInterface;
 use Ibexa\Contracts\Core\Repository\Values\Content\Query;
 use Ibexa\Contracts\Core\Repository\Values\Content\Query\SortClause\ContentName;
 use Ibexa\Contracts\Core\Repository\Values\Content\Query\SortClause\ContentTranslatedName;
@@ -21,11 +21,11 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 
 final class NameSortingDefinitionProvider implements SortingDefinitionProviderInterface, TranslationContainerInterface
 {
-    private RepositoryConfigurationProvider $configurationProvider;
+    private RepositoryConfigurationProviderInterface $configurationProvider;
 
     private TranslatorInterface $translator;
 
-    public function __construct(RepositoryConfigurationProvider $configurationProvider, TranslatorInterface $translator)
+    public function __construct(RepositoryConfigurationProviderInterface $configurationProvider, TranslatorInterface $translator)
     {
         $this->configurationProvider = $configurationProvider;
         $this->translator = $translator;

--- a/tests/lib/EventDispatcher/EventListener/ContentSuggestionSubscriberTest.php
+++ b/tests/lib/EventDispatcher/EventListener/ContentSuggestionSubscriberTest.php
@@ -8,7 +8,7 @@ declare(strict_types=1);
 
 namespace Ibexa\Tests\Search\EventDispatcher\EventListener;
 
-use Ibexa\Bundle\Core\ApiLoader\RepositoryConfigurationProvider;
+use Ibexa\Contracts\Core\Container\ApiLoader\RepositoryConfigurationProviderInterface;
 use Ibexa\Contracts\Core\Exception\InvalidArgumentException;
 use Ibexa\Contracts\Core\Repository\SearchService as SearchServiceInterface;
 use Ibexa\Contracts\Core\Repository\Values\Content\Content;
@@ -33,8 +33,8 @@ use Psr\Log\LoggerInterface;
 
 final class ContentSuggestionSubscriberTest extends TestCase
 {
-    /** @var \Ibexa\Bundle\Core\ApiLoader\RepositoryConfigurationProvider&\PHPUnit\Framework\MockObject\MockObject */
-    private RepositoryConfigurationProvider $configProviderMock;
+    /** @var \Ibexa\Contracts\Core\Container\ApiLoader\RepositoryConfigurationProviderInterface&\PHPUnit\Framework\MockObject\MockObject */
+    private RepositoryConfigurationProviderInterface $configProviderMock;
 
     private ?Query $capturedQuery;
 
@@ -45,7 +45,7 @@ final class ContentSuggestionSubscriberTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->configProviderMock = $this->createMock(RepositoryConfigurationProvider::class);
+        $this->configProviderMock = $this->createMock(RepositoryConfigurationProviderInterface::class);
         $this->capturedQuery = null;
         $this->searchServiceSupportsScoring = false;
         $this->loggerMock = $this->createMock(LoggerInterface::class);

--- a/tests/lib/SortingDefinition/Provider/NameSortingDefinitionProviderTest.php
+++ b/tests/lib/SortingDefinition/Provider/NameSortingDefinitionProviderTest.php
@@ -8,7 +8,7 @@ declare(strict_types=1);
 
 namespace Ibexa\Tests\Search\SortingDefinition\Provider;
 
-use Ibexa\Bundle\Core\ApiLoader\RepositoryConfigurationProvider;
+use Ibexa\Contracts\Core\Container\ApiLoader\RepositoryConfigurationProviderInterface;
 use Ibexa\Contracts\Core\Repository\Values\Content\Query;
 use Ibexa\Contracts\Core\Repository\Values\Content\Query\SortClause\ContentName;
 use Ibexa\Contracts\Core\Repository\Values\Content\Query\SortClause\ContentTranslatedName;
@@ -22,8 +22,8 @@ final class NameSortingDefinitionProviderTest extends TestCase
     /** @var \Symfony\Contracts\Translation\TranslatorInterface&\PHPUnit\Framework\MockObject\MockObject */
     private TranslatorInterface $translator;
 
-    /** @var \Ibexa\Bundle\Core\ApiLoader\RepositoryConfigurationProvider&\PHPUnit\Framework\MockObject\MockObject */
-    private RepositoryConfigurationProvider $configurationProvider;
+    /** @var \Ibexa\Contracts\Core\Container\ApiLoader\RepositoryConfigurationProviderInterface&\PHPUnit\Framework\MockObject\MockObject */
+    private RepositoryConfigurationProviderInterface $configurationProvider;
 
     private NameSortingDefinitionProvider $provider;
 
@@ -32,7 +32,7 @@ final class NameSortingDefinitionProviderTest extends TestCase
         $this->translator = $this->createMock(TranslatorInterface::class);
         $this->translator->method('trans')->willReturnArgument(0);
 
-        $this->configurationProvider = $this->createMock(RepositoryConfigurationProvider::class);
+        $this->configurationProvider = $this->createMock(RepositoryConfigurationProviderInterface::class);
 
         $this->provider = new NameSortingDefinitionProvider(
             $this->configurationProvider,


### PR DESCRIPTION
| :ticket: Issue | IBX-8394 |
|----------------|-----------|

#### Description:

Replaced usages of `\Ibexa\Bundle\Core\ApiLoader\RepositoryConfigurationProvider`
with `\Ibexa\Contracts\Core\Container\ApiLoader\RepositoryConfigurationProviderInterface`, using ibexa/rector#6.

#### For QA:

No QA needed. Regression tests should be enough.

#### Documentation:

This is code refactoring without behavior change. No documentation changes needed.
