### PR TITLE
IBX-9584: Resolved Symfony 6.x deprecations

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -36,6 +36,31 @@ jobs:
             - name: Run PHPStan analysis
               run: composer run-script phpstan
 
+    rector:
+        name: Run rector
+        runs-on: "ubuntu-22.04"
+        strategy:
+            matrix:
+                php:
+                    - '8.3'
+        steps:
+            -   uses: actions/checkout@v4
+
+            -   name: Setup PHP Action
+                uses: shivammathur/setup-php@v2
+                with:
+                    php-version: ${{ matrix.php }}
+                    coverage: none
+                    extensions: 'pdo_sqlite, gd'
+                    tools: cs2pr
+
+            -   uses: ramsey/composer-install@v3
+                with:
+                    dependency-versions: highest
+
+            -   name: Run rector
+                run: vendor/bin/rector process --dry-run --ansi
+
     tests:
         name: Unit tests
         runs-on: "ubuntu-22.04"

--- a/composer.json
+++ b/composer.json
@@ -35,6 +35,7 @@
     "require-dev": {
         "ibexa/code-style": "~2.0.0",
         "ibexa/doctrine-schema": "~5.0.x-dev",
+        "ibexa/rector": "~5.0.x-dev",
         "matthiasnoback/symfony-dependency-injection-test": "^4.3",
         "phpstan/phpstan": "^1.10",
         "phpstan/phpstan-phpunit": "^1.3",

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -161,31 +161,6 @@ parameters:
 			path: src/bundle/Form/DataTransformer/UsersTransformer.php
 
 		-
-			message: "#^Method Ibexa\\\\Bundle\\\\Search\\\\Form\\\\Type\\\\DateIntervalType\\:\\:buildForm\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/bundle/Form/Type/DateIntervalType.php
-
-		-
-			message: "#^Method Ibexa\\\\Bundle\\\\Search\\\\Form\\\\Type\\\\SearchType\\:\\:buildForm\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/bundle/Form/Type/SearchType.php
-
-		-
-			message: "#^Method Ibexa\\\\Bundle\\\\Search\\\\Form\\\\Type\\\\SearchType\\:\\:buildForm\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/bundle/Form/Type/SearchType.php
-
-		-
-			message: "#^Method Ibexa\\\\Bundle\\\\Search\\\\Form\\\\Type\\\\SearchUsersType\\:\\:buildForm\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/bundle/Form/Type/SearchUsersType.php
-
-		-
-			message: "#^Method Ibexa\\\\Bundle\\\\Search\\\\Form\\\\Type\\\\UserType\\:\\:buildForm\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/bundle/Form/Type/UserType.php
-
-		-
 			message: "#^Method Ibexa\\\\Contracts\\\\Search\\\\Mapper\\\\SearchHitToContentSuggestionMapperInterface\\:\\:map\\(\\) has parameter \\$searchHit with generic class Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\Content\\\\Search\\\\SearchHit but does not specify its types\\: T$#"
 			count: 1
 			path: src/contracts/Mapper/SearchHitToContentSuggestionMapperInterface.php

--- a/rector.php
+++ b/rector.php
@@ -20,4 +20,6 @@ return RectorConfig::configure()
         SymfonySetList::SYMFONY_60,
         SymfonySetList::SYMFONY_61,
         SymfonySetList::SYMFONY_62,
+        SymfonySetList::SYMFONY_63,
+        SymfonySetList::SYMFONY_64,
     ]);

--- a/rector.php
+++ b/rector.php
@@ -1,0 +1,21 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+use Ibexa\Contracts\Rector\Sets\IbexaSetList;
+use Rector\Config\RectorConfig;
+use Rector\Symfony\Set\SymfonySetList;
+
+return RectorConfig::configure()
+    ->withPaths([
+        __DIR__ . '/src',
+        __DIR__ . '/tests',
+    ])
+    ->withSets([
+        IbexaSetList::IBEXA_50->value,
+        SymfonySetList::SYMFONY_60,
+    ]);

--- a/rector.php
+++ b/rector.php
@@ -18,4 +18,6 @@ return RectorConfig::configure()
     ->withSets([
         IbexaSetList::IBEXA_50->value,
         SymfonySetList::SYMFONY_60,
+        SymfonySetList::SYMFONY_61,
+        SymfonySetList::SYMFONY_62,
     ]);

--- a/src/bundle/Form/Type/ContentTypeChoiceType.php
+++ b/src/bundle/Form/Type/ContentTypeChoiceType.php
@@ -35,7 +35,7 @@ class ContentTypeChoiceType extends AbstractType
         return ChoiceType::class;
     }
 
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver
             ->setDefaults([

--- a/src/bundle/Form/Type/DateIntervalType.php
+++ b/src/bundle/Form/Type/DateIntervalType.php
@@ -18,7 +18,7 @@ class DateIntervalType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('start_date', DateType::class, [

--- a/src/bundle/Form/Type/DateIntervalType.php
+++ b/src/bundle/Form/Type/DateIntervalType.php
@@ -15,9 +15,6 @@ use Symfony\Component\Form\FormBuilderInterface;
 
 class DateIntervalType extends AbstractType
 {
-    /**
-     * {@inheritdoc}
-     */
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder

--- a/src/bundle/Form/Type/SearchType.php
+++ b/src/bundle/Form/Type/SearchType.php
@@ -34,12 +34,6 @@ final class SearchType extends AbstractType
         $this->configResolver = $configResolver;
     }
 
-    /**
-     * @param \Symfony\Component\Form\FormBuilderInterface $builder
-     * @param array $options
-     *
-     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException
-     */
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
@@ -90,11 +84,6 @@ final class SearchType extends AbstractType
         );
     }
 
-    /**
-     * {@inheritdoc}
-     *
-     * @throws \Symfony\Component\OptionsResolver\Exception\AccessException
-     */
     public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([

--- a/src/bundle/Form/Type/SearchType.php
+++ b/src/bundle/Form/Type/SearchType.php
@@ -40,7 +40,7 @@ final class SearchType extends AbstractType
      *
      * @throws \Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('query', CoreTextType::class, ['required' => false])
@@ -95,7 +95,7 @@ final class SearchType extends AbstractType
      *
      * @throws \Symfony\Component\OptionsResolver\Exception\AccessException
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
             'data_class' => SearchData::class,

--- a/src/bundle/Form/Type/SearchUsersType.php
+++ b/src/bundle/Form/Type/SearchUsersType.php
@@ -38,7 +38,7 @@ class SearchUsersType extends AbstractType
         $this->userContentTypeIdentifier = $userContentTypeIdentifier;
     }
 
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder->addViewTransformer(
             new UsersTransformer(
@@ -54,7 +54,7 @@ class SearchUsersType extends AbstractType
         return TextType::class;
     }
 
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
             'data_class' => SearchUsersData::class,

--- a/src/bundle/Form/Type/SectionChoiceType.php
+++ b/src/bundle/Form/Type/SectionChoiceType.php
@@ -31,7 +31,7 @@ class SectionChoiceType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
             'choices' => $this->sectionService->loadSections(),

--- a/src/bundle/Form/Type/SectionChoiceType.php
+++ b/src/bundle/Form/Type/SectionChoiceType.php
@@ -18,19 +18,11 @@ class SectionChoiceType extends AbstractType
     /** @var \Ibexa\Contracts\Core\Repository\SectionService */
     private $sectionService;
 
-    /**
-     * SectionChoiceType constructor.
-     *
-     * @param \Ibexa\Contracts\Core\Repository\SectionService $sectionService
-     */
     public function __construct(SectionService $sectionService)
     {
         $this->sectionService = $sectionService;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
@@ -40,9 +32,6 @@ class SectionChoiceType extends AbstractType
         ]);
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function getParent(): ?string
     {
         return ChoiceType::class;

--- a/src/bundle/Form/Type/UserType.php
+++ b/src/bundle/Form/Type/UserType.php
@@ -24,7 +24,7 @@ class UserType extends AbstractType
         $this->userService = $userService;
     }
 
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder->addViewTransformer(new UserTransformer($this->userService));
     }

--- a/src/bundle/Resources/config/services/suggestions.yaml
+++ b/src/bundle/Resources/config/services/suggestions.yaml
@@ -4,7 +4,7 @@ services:
         autowire: true
         public: false
 
-    Ibexa\Bundle\Search\ArgumentResolver\SuggestionQueryArgumentResolver:
+    Ibexa\Bundle\Search\ValueResolver\SuggestionQueryArgumentResolver:
         tags:
             - { name: 'controller.argument_value_resolver' }
 


### PR DESCRIPTION
| :ticket: Issue | IBX-9584  |
|----------------|-----------|

<!-- 
#### Related PRs: 
- https://github.com/ibexa/core/pull/1
-->

#### Description:
Enabled and executed automatic refactoring rules defined for Symfony 6.x.

* [Form] Removed redundant PHPDocs
* [Form] Added missing return type declarations
* [HTTP] Migrated from ArgumentValueResolvedInterface to ValueResolverInterfaceInterface

Additionally added rector job to CI setup to prevent merging up code which is not compatible with Symfony 6+.

#### For QA:
Sanities.

#### Documentation:
N/A

<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
