### PR TITLE
IBX-9727: Added missing type hints

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -61,12 +61,6 @@ parameters:
 			path: src/bundle/Form/Data/SearchData.php
 
 		-
-			message: '#^Method Ibexa\\Bundle\\Search\\Form\\Data\\SearchData\:\:getSearchUsersData\(\) should return Ibexa\\Bundle\\Search\\Form\\Data\\SearchUsersData\|null but returns array\<Ibexa\\Contracts\\Core\\Repository\\Values\\User\\User\>\.$#'
-			identifier: return.type
-			count: 1
-			path: src/bundle/Form/Data/SearchData.php
-
-		-
 			message: '#^Method Ibexa\\Bundle\\Search\\Form\\Data\\SearchData\:\:setContentTypes\(\) has parameter \$contentTypes with no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
@@ -91,33 +85,9 @@ parameters:
 			path: src/bundle/Form/Data/SearchData.php
 
 		-
-			message: '#^Property Ibexa\\Bundle\\Search\\Form\\Data\\SearchData\:\:\$creator \(Ibexa\\Contracts\\Core\\Repository\\Values\\User\\User\) does not accept Ibexa\\Contracts\\Core\\Repository\\Values\\User\\User\|null\.$#'
-			identifier: assign.propertyType
-			count: 1
-			path: src/bundle/Form/Data/SearchData.php
-
-		-
 			message: '#^Property Ibexa\\Bundle\\Search\\Form\\Data\\SearchData\:\:\$lastModified type has no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
-			path: src/bundle/Form/Data/SearchData.php
-
-		-
-			message: '#^Property Ibexa\\Bundle\\Search\\Form\\Data\\SearchData\:\:\$query \(string\) does not accept string\|null\.$#'
-			identifier: assign.propertyType
-			count: 2
-			path: src/bundle/Form/Data/SearchData.php
-
-		-
-			message: '#^Property Ibexa\\Bundle\\Search\\Form\\Data\\SearchData\:\:\$searchUsersData \(array\<Ibexa\\Contracts\\Core\\Repository\\Values\\User\\User\>\) does not accept Ibexa\\Bundle\\Search\\Form\\Data\\SearchUsersData\|null\.$#'
-			identifier: assign.propertyType
-			count: 2
-			path: src/bundle/Form/Data/SearchData.php
-
-		-
-			message: '#^Property Ibexa\\Bundle\\Search\\Form\\Data\\SearchData\:\:\$section \(Ibexa\\Contracts\\Core\\Repository\\Values\\Content\\Section\) does not accept Ibexa\\Contracts\\Core\\Repository\\Values\\Content\\Section\|null\.$#'
-			identifier: assign.propertyType
-			count: 2
 			path: src/bundle/Form/Data/SearchData.php
 
 		-
@@ -136,12 +106,6 @@ parameters:
 			message: '#^Method Ibexa\\Bundle\\Search\\Form\\Data\\SearchUsersData\:\:setPossibleUsers\(\) has parameter \$possibleUsers with no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
-			path: src/bundle/Form/Data/SearchUsersData.php
-
-		-
-			message: '#^Property Ibexa\\Bundle\\Search\\Form\\Data\\SearchUsersData\:\:\$query \(string\) does not accept string\|null\.$#'
-			identifier: assign.propertyType
-			count: 2
 			path: src/bundle/Form/Data/SearchUsersData.php
 
 		-

--- a/src/bundle/Form/ChoiceLoader/ContentTypeChoiceLoader.php
+++ b/src/bundle/Form/ChoiceLoader/ContentTypeChoiceLoader.php
@@ -33,7 +33,7 @@ class ContentTypeChoiceLoader implements ChoiceLoaderInterface
         $contentTypeGroups = $this->contentTypeService->loadContentTypeGroups($preferredLanguages);
         foreach ($contentTypeGroups as $contentTypeGroup) {
             $contentTypes = $this->contentTypeService->loadContentTypes($contentTypeGroup, $preferredLanguages);
-            usort($contentTypes, static function (ContentType $contentType1, ContentType $contentType2) {
+            usort($contentTypes, static function (ContentType $contentType1, ContentType $contentType2): int {
                 return strnatcasecmp($contentType1->getName(), $contentType2->getName());
             });
 

--- a/src/bundle/Form/Data/SearchData.php
+++ b/src/bundle/Form/Data/SearchData.php
@@ -38,7 +38,6 @@ class SearchData
 
     private ?Language $searchLanguage;
 
-    /** @var \Ibexa\Contracts\Core\Repository\Values\User\User[] */
     private ?SearchUsersData $searchUsersData;
 
     private ?SortingDefinitionInterface $sortingDefinition;

--- a/src/bundle/Form/Data/SearchData.php
+++ b/src/bundle/Form/Data/SearchData.php
@@ -16,41 +16,30 @@ use Symfony\Component\Validator\Constraints as Assert;
 
 class SearchData
 {
-    /**
-     * @var int
-     */
     #[Assert\Range(max: 1000)]
-    private $limit;
+    private int $limit;
 
-    /** @var int */
-    private $page;
+    private int $page;
 
-    /** @var string */
-    private $query;
+    private ?string $query;
 
-    /** @var \Ibexa\Contracts\Core\Repository\Values\Content\Section */
-    private $section;
+    private ?Section $section;
 
     /** @var \Ibexa\Contracts\Core\Repository\Values\ContentType\ContentType[] */
-    private $contentTypes;
+    private array $contentTypes;
 
-    /** @var array */
-    private $lastModified;
+    private array $lastModified;
 
-    /** @var array */
-    private $created;
+    private array $created;
 
-    /** @var \Ibexa\Contracts\Core\Repository\Values\User\User */
-    private $creator;
+    private ?User $creator;
 
-    /** @var string|null */
-    private $subtree;
+    private ?string $subtree;
 
-    /** @var \Ibexa\Contracts\Core\Repository\Values\Content\Language|null */
-    private $searchLanguage;
+    private ?Language $searchLanguage;
 
     /** @var \Ibexa\Contracts\Core\Repository\Values\User\User[] */
-    private $searchUsersData;
+    private ?SearchUsersData $searchUsersData;
 
     private ?SortingDefinitionInterface $sortingDefinition;
 
@@ -224,7 +213,7 @@ class SearchData
             null !== $section ||
             !empty($lastModified) ||
             !empty($created) ||
-            !empty($creator) ||
+            $creator instanceof User ||
             null !== $subtree;
     }
 }

--- a/src/bundle/Form/Data/SearchUsersData.php
+++ b/src/bundle/Form/Data/SearchUsersData.php
@@ -10,11 +10,10 @@ namespace Ibexa\Bundle\Search\Form\Data;
 
 class SearchUsersData
 {
-    /** @var string */
-    private $query;
+    private ?string $query;
 
     /** @var \Ibexa\Contracts\Core\Repository\Values\Content\Content[] */
-    private $possibleUsers;
+    private array $possibleUsers;
 
     public function __construct(array $possibleUsers = [], ?string $query = null)
     {

--- a/src/bundle/Form/DataTransformer/UserTransformer.php
+++ b/src/bundle/Form/DataTransformer/UserTransformer.php
@@ -19,8 +19,7 @@ use Symfony\Component\Form\Exception\TransformationFailedException;
  */
 class UserTransformer implements DataTransformerInterface
 {
-    /** @var \Ibexa\Contracts\Core\Repository\UserService */
-    protected $userService;
+    protected UserService $userService;
 
     /**
      * @param \Ibexa\Contracts\Core\Repository\UserService $userService

--- a/src/bundle/Form/DataTransformer/UsersTransformer.php
+++ b/src/bundle/Form/DataTransformer/UsersTransformer.php
@@ -22,14 +22,11 @@ use Symfony\Component\Form\Exception\TransformationFailedException;
  */
 class UsersTransformer implements DataTransformerInterface
 {
-    /** @var \Ibexa\Contracts\Core\Repository\Repository */
-    private $repository;
+    private Repository $repository;
 
-    /** @var \Ibexa\Contracts\Core\Repository\SearchService */
-    private $searchService;
+    private SearchService $searchService;
 
-    /** @var string */
-    private $userContentTypeIdentifier;
+    private string $userContentTypeIdentifier;
 
     public function __construct(
         Repository $repository,

--- a/src/bundle/Form/Type/ContentTypeChoiceType.php
+++ b/src/bundle/Form/Type/ContentTypeChoiceType.php
@@ -16,11 +16,9 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class ContentTypeChoiceType extends AbstractType
 {
-    /** @var \Ibexa\Contracts\Core\Repository\ContentTypeService */
-    protected $contentTypeService;
+    protected ContentTypeService $contentTypeService;
 
-    /** @var \Ibexa\Bundle\Search\Form\ChoiceLoader\ContentTypeChoiceLoader */
-    private $contentTypeChoiceLoader;
+    private ContentTypeChoiceLoader $contentTypeChoiceLoader;
 
     public function __construct(
         ContentTypeService $contentTypeService,

--- a/src/bundle/Form/Type/LanguageChoiceType.php
+++ b/src/bundle/Form/Type/LanguageChoiceType.php
@@ -15,8 +15,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class LanguageChoiceType extends AbstractType
 {
-    /** @var \Symfony\Component\Form\ChoiceList\Loader\ChoiceLoaderInterface */
-    private $languageChoiceLoader;
+    private ChoiceLoaderInterface $languageChoiceLoader;
 
     public function __construct(ChoiceLoaderInterface $languageChoiceLoader)
     {

--- a/src/bundle/Form/Type/SearchType.php
+++ b/src/bundle/Form/Type/SearchType.php
@@ -20,11 +20,9 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 
 final class SearchType extends AbstractType
 {
-    /** @var \Ibexa\Contracts\Core\Repository\PermissionResolver */
-    private $permissionResolver;
+    private PermissionResolver $permissionResolver;
 
-    /** @var \Ibexa\Contracts\Core\SiteAccess\ConfigResolverInterface */
-    private $configResolver;
+    private ConfigResolverInterface $configResolver;
 
     public function __construct(
         PermissionResolver $permissionResolver,

--- a/src/bundle/Form/Type/SearchUsersType.php
+++ b/src/bundle/Form/Type/SearchUsersType.php
@@ -19,14 +19,11 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class SearchUsersType extends AbstractType
 {
-    /** @var \Ibexa\Contracts\Core\Repository\Repository */
-    private $repository;
+    private Repository $repository;
 
-    /** @var \Ibexa\Contracts\Core\Repository\SearchService */
-    private $searchService;
+    private SearchService $searchService;
 
-    /** @var string */
-    private $userContentTypeIdentifier;
+    private string $userContentTypeIdentifier;
 
     public function __construct(
         Repository $repository,

--- a/src/bundle/Form/Type/SectionChoiceType.php
+++ b/src/bundle/Form/Type/SectionChoiceType.php
@@ -15,8 +15,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class SectionChoiceType extends AbstractType
 {
-    /** @var \Ibexa\Contracts\Core\Repository\SectionService */
-    private $sectionService;
+    private SectionService $sectionService;
 
     public function __construct(SectionService $sectionService)
     {

--- a/src/bundle/Form/Type/UserType.php
+++ b/src/bundle/Form/Type/UserType.php
@@ -16,8 +16,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 
 class UserType extends AbstractType
 {
-    /** @var \Ibexa\Contracts\Core\Repository\UserService */
-    protected $userService;
+    protected UserService $userService;
 
     public function __construct(UserService $userService)
     {

--- a/src/lib/Mapper/PagerSearchContentToDataMapper.php
+++ b/src/lib/Mapper/PagerSearchContentToDataMapper.php
@@ -42,23 +42,17 @@ use Pagerfanta\Pagerfanta;
  */
 class PagerSearchContentToDataMapper
 {
-    /** @var \Ibexa\Contracts\Core\Repository\ContentTypeService */
-    private $contentTypeService;
+    private ContentTypeService $contentTypeService;
 
-    /** @var \Ibexa\Contracts\Core\Repository\UserService */
-    private $userService;
+    private UserService $userService;
 
-    /** @var \Ibexa\Core\MVC\Symfony\Locale\UserLanguagePreferenceProviderInterface */
-    private $userLanguagePreferenceProvider;
+    private UserLanguagePreferenceProviderInterface $userLanguagePreferenceProvider;
 
-    /** @var \Ibexa\Core\Helper\TranslationHelper */
-    protected $translationHelper;
+    protected TranslationHelper $translationHelper;
 
-    /** @var \Ibexa\Contracts\Core\Repository\LanguageService */
-    private $languageService;
+    private LanguageService $languageService;
 
-    /** @var \Ibexa\Core\Repository\LocationResolver\LocationResolver */
-    private $locationResolver;
+    private LocationResolver $locationResolver;
 
     public function __construct(
         ContentTypeService $contentTypeService,

--- a/src/lib/View/SearchViewBuilder.php
+++ b/src/lib/View/SearchViewBuilder.php
@@ -20,20 +20,15 @@ use Pagerfanta\Pagerfanta;
 
 class SearchViewBuilder implements ViewBuilder
 {
-    /** @var \Ibexa\Core\MVC\Symfony\View\Configurator */
-    private $viewConfigurator;
+    private Configurator $viewConfigurator;
 
-    /** @var \Ibexa\Core\MVC\Symfony\View\ParametersInjector */
-    private $viewParametersInjector;
+    private ParametersInjector $viewParametersInjector;
 
-    /** @var \Ibexa\Contracts\Core\Repository\SearchService */
-    private $searchService;
+    private SearchService $searchService;
 
-    /** @var \Ibexa\Search\Mapper\PagerSearchContentToDataMapper */
-    private $pagerSearchContentToDataMapper;
+    private PagerSearchContentToDataMapper $pagerSearchContentToDataMapper;
 
-    /** @var \Ibexa\Core\QueryType\QueryType */
-    private $searchQueryType;
+    private QueryType $searchQueryType;
 
     public function __construct(
         Configurator $viewConfigurator,

--- a/src/lib/View/SearchViewFilter.php
+++ b/src/lib/View/SearchViewFilter.php
@@ -22,20 +22,15 @@ use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 class SearchViewFilter implements EventSubscriberInterface
 {
-    /** @var \Ibexa\Contracts\Core\SiteAccess\ConfigResolverInterface */
-    private $configResolver;
+    private ConfigResolverInterface $configResolver;
 
-    /** @var \Symfony\Component\Form\FormFactoryInterface */
-    private $formFactory;
+    private FormFactoryInterface $formFactory;
 
-    /** @var \Ibexa\Contracts\Core\Repository\SectionService */
-    private $sectionService;
+    private SectionService $sectionService;
 
-    /** @var \Ibexa\Contracts\Core\Repository\ContentTypeService */
-    private $contentTypeService;
+    private ContentTypeService $contentTypeService;
 
-    /** @var \Symfony\Component\Routing\Generator\UrlGeneratorInterface */
-    private $urlGenerator;
+    private UrlGeneratorInterface $urlGenerator;
 
     public function __construct(
         ConfigResolverInterface $configResolver,

--- a/src/lib/View/SearchViewProvider.php
+++ b/src/lib/View/SearchViewProvider.php
@@ -15,8 +15,7 @@ use Symfony\Component\HttpKernel\Controller\ControllerReference;
 
 class SearchViewProvider implements ViewProvider
 {
-    /** @var \Ibexa\Core\MVC\Symfony\Matcher\MatcherFactoryInterface */
-    protected $matcherFactory;
+    protected MatcherFactoryInterface $matcherFactory;
 
     public function __construct(MatcherFactoryInterface $matcherFactory)
     {

--- a/tests/lib/Service/Event/SuggestionServiceTest.php
+++ b/tests/lib/Service/Event/SuggestionServiceTest.php
@@ -15,6 +15,7 @@ use Ibexa\Contracts\Search\Service\SuggestionServiceInterface;
 use Ibexa\Search\Model\SuggestionQuery;
 use Ibexa\Search\Service\Event\SuggestionService;
 use LogicException;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Contracts\EventDispatcher\Event;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
@@ -22,10 +23,10 @@ use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 final class SuggestionServiceTest extends TestCase
 {
     /** @var \Ibexa\Contracts\Search\Service\SuggestionServiceInterface|\PHPUnit\Framework\MockObject\MockObject */
-    private $innerServiceMock;
+    private MockObject $innerServiceMock;
 
     /** @var \Symfony\Contracts\EventDispatcher\EventDispatcherInterface|\PHPUnit\Framework\MockObject\MockObject */
-    private $eventDispatcherMock;
+    private MockObject $eventDispatcherMock;
 
     protected function setUp(): void
     {

--- a/tests/lib/Service/Event/SuggestionServiceTest.php
+++ b/tests/lib/Service/Event/SuggestionServiceTest.php
@@ -22,11 +22,9 @@ use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
 final class SuggestionServiceTest extends TestCase
 {
-    /** @var \Ibexa\Contracts\Search\Service\SuggestionServiceInterface|\PHPUnit\Framework\MockObject\MockObject */
-    private MockObject $innerServiceMock;
+    private SuggestionServiceInterface&MockObject $innerServiceMock;
 
-    /** @var \Symfony\Contracts\EventDispatcher\EventDispatcherInterface|\PHPUnit\Framework\MockObject\MockObject */
-    private MockObject $eventDispatcherMock;
+    private EventDispatcherInterface&MockObject $eventDispatcherMock;
 
     protected function setUp(): void
     {


### PR DESCRIPTION
> [!CAUTION]
> These changes are volatile and - in some repositories - extensive, so they need to be carefully reviewed before merging.

| :ticket: Issue | IBX-9727 |
|----------------|-----------|

#### Description:

Added missing strict type hints using `\Rector\Set\ValueObject\SetList::TYPE_DECLARATION` set.
Additionally FQCNs have been imported for every affected file using PHP CS Fixer, in some cases they might override unrelated lines.

#### For QA:

Regression tests.
