### PR TITLE
[PHPStan] Resolved phpstan issues

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -229,6 +229,12 @@ parameters:
 			path: src/lib/Mapper/PagerSearchContentToDataMapper.php
 
 		-
+			message: '#^Parameter \#1 \$data of method Ibexa\\Search\\Mapper\\PagerSearchContentToDataMapper\:\:setTranslatedContentTypesNames\(\) expects array\<array\{content\: Ibexa\\Contracts\\Core\\Repository\\Values\\Content\\Content, contentTypeId\: int, contentId\: int, name\: string, language\: string, contributor\: Ibexa\\Contracts\\Core\\Repository\\Values\\User\\User\|null, version\: int, content_type\: Ibexa\\Contracts\\Core\\Repository\\Values\\ContentType\\ContentType, \.\.\.\}\>, list\<array\{content\: Ibexa\\Contracts\\Core\\Repository\\Values\\Content\\Content, contentTypeId\: int, contentId\: int, mainLocationId\: int\|null, name\: string, language\: string, contributor\: Ibexa\\Contracts\\Core\\Repository\\Values\\User\\User\|null, version\: int, \.\.\.\}\> given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/lib/Mapper/PagerSearchContentToDataMapper.php
+
+		-
 			message: '#^Parameter &\$data by\-ref type of method Ibexa\\Search\\Mapper\\PagerSearchContentToDataMapper\:\:setTranslatedContentTypesNames\(\) expects array\<array\{content\: Ibexa\\Contracts\\Core\\Repository\\Values\\Content\\Content, contentTypeId\: int, contentId\: int, name\: string, language\: string, contributor\: Ibexa\\Contracts\\Core\\Repository\\Values\\User\\User\|null, version\: int, content_type\: Ibexa\\Contracts\\Core\\Repository\\Values\\ContentType\\ContentType, \.\.\.\}\>, non\-empty\-array\<array\{content\?\: Ibexa\\Contracts\\Core\\Repository\\Values\\Content\\Content, contentTypeId\?\: int, contentId\: int, name\: string, language\: string, contributor\: Ibexa\\Contracts\\Core\\Repository\\Values\\User\\User\|null, version\: int, content_type\: Ibexa\\Contracts\\Core\\Repository\\Values\\ContentType\\ContentType, \.\.\.\}\> given\.$#'
 			identifier: parameterByRef.type
 			count: 3
@@ -237,12 +243,6 @@ parameters:
 		-
 			message: '#^Method Ibexa\\Search\\Mapper\\SearchHitToContentSuggestionMapper\:\:map\(\) has parameter \$searchHit with generic class Ibexa\\Contracts\\Core\\Repository\\Values\\Content\\Search\\SearchHit but does not specify its types\: T$#'
 			identifier: missingType.generics
-			count: 1
-			path: src/lib/Mapper/SearchHitToContentSuggestionMapper.php
-
-		-
-			message: '#^Property Ibexa\\Contracts\\Core\\Repository\\Values\\Content\\Search\\SearchHit\<Ibexa\\Contracts\\Core\\Repository\\Values\\ValueObject\>\:\:\$score \(float\) on left side of \?\? is not nullable\.$#'
-			identifier: nullCoalesce.property
 			count: 1
 			path: src/lib/Mapper/SearchHitToContentSuggestionMapper.php
 

--- a/src/bundle/Form/ChoiceList/View/FacetView.php
+++ b/src/bundle/Form/ChoiceList/View/FacetView.php
@@ -11,10 +11,21 @@ namespace Ibexa\Bundle\Search\Form\ChoiceList\View;
 use Ibexa\Contracts\Core\Repository\Values\Content\Search\AggregationResult\TermAggregationResultEntry;
 use Symfony\Component\Form\ChoiceList\View\ChoiceView;
 
+/**
+ * @phpstan-template TKey of object|scalar
+ */
 final class FacetView extends ChoiceView
 {
+    /**
+     * @phpstan-var \Ibexa\Contracts\Core\Repository\Values\Content\Search\AggregationResult\TermAggregationResultEntry<TKey>|null
+     */
     public ?TermAggregationResultEntry $term = null;
 
+    /**
+     * @phpstan-param \Ibexa\Contracts\Core\Repository\Values\Content\Search\AggregationResult\TermAggregationResultEntry<TKey>|null $term
+     *
+     * @phpstan-return \Ibexa\Bundle\Search\Form\ChoiceList\View\FacetView<TKey>
+     */
     public static function createFromChoiceView(ChoiceView $choiceView, ?TermAggregationResultEntry $term): self
     {
         $facet = new self(
@@ -27,6 +38,7 @@ final class FacetView extends ChoiceView
 
         $facet->term = $term;
 
+        /** @phpstan-var \Ibexa\Bundle\Search\Form\ChoiceList\View\FacetView<TKey> */
         return $facet;
     }
 }

--- a/src/bundle/Twig/Extension/SearchFacetsExtension.php
+++ b/src/bundle/Twig/Extension/SearchFacetsExtension.php
@@ -37,8 +37,11 @@ final class SearchFacetsExtension extends AbstractExtension
     }
 
     /**
-     * @param \Symfony\Component\Form\ChoiceList\View\ChoiceView[]|\Symfony\Component\Form\ChoiceList\View\ChoiceGroupView[] $choices
-     * @param callable(ChoiceView, TermAggregationResultEntry): bool|null $comparator
+     * @phpstan-template TKey of object|scalar
+     *
+     * @phpstan-param \Ibexa\Contracts\Core\Repository\Values\Content\Search\AggregationResult\TermAggregationResult<TKey>|null $terms
+     * @phpstan-param \Symfony\Component\Form\ChoiceList\View\ChoiceView[]|\Symfony\Component\Form\ChoiceList\View\ChoiceGroupView[] $choices
+     * @phpstan-param callable(ChoiceView, TermAggregationResultEntry<TKey>): bool|null $comparator
      *
      * @return \Symfony\Component\Form\ChoiceList\View\ChoiceView[]|\Symfony\Component\Form\ChoiceList\View\ChoiceGroupView[]
      */
@@ -86,7 +89,12 @@ final class SearchFacetsExtension extends AbstractExtension
     }
 
     /**
-     * @param callable(ChoiceView, TermAggregationResultEntry): bool $comparator
+     * @phpstan-template TKey of object|scalar
+     *
+     * @phpstan-param \Ibexa\Contracts\Core\Repository\Values\Content\Search\AggregationResult\TermAggregationResult<TKey> $terms
+     * @phpstan-param callable(ChoiceView, TermAggregationResultEntry<TKey>): bool $comparator
+     *
+     * @phpstan-return \Ibexa\Contracts\Core\Repository\Values\Content\Search\AggregationResult\TermAggregationResultEntry<TKey>|null
      */
     private function findTermEntry(
         TermAggregationResult $terms,


### PR DESCRIPTION
| :ticket: Issue | N/A       |
|----------------|-----------|

<!-- 
#### Related PRs: 
- https://github.com/ibexa/core/pull/1
-->

#### Description:
```
4s
Run composer run-script phpstan
> phpstan analyse
Note: Using configuration file /home/runner/work/search/search/phpstan.neon.
  0/79 [░░░░░░░░░░░░░░░░░░░░░░░░░░░░]   0%
 79/79 [▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓] 100%

Error: Property Ibexa\Bundle\Search\Form\ChoiceList\View\FacetView::$term with generic class Ibexa\Contracts\Core\Repository\Values\Content\Search\AggregationResult\TermAggregationResultEntry does not specify its types: TKey
Error: Method Ibexa\Bundle\Search\Form\ChoiceList\View\FacetView::createFromChoiceView() has parameter $term with generic class Ibexa\Contracts\Core\Repository\Values\Content\Search\AggregationResult\TermAggregationResultEntry but does not specify its types: TKey
Error: Method Ibexa\Bundle\Search\Twig\Extension\SearchFacetsExtension::getChoicesAsFacets() has parameter $comparator with generic class Ibexa\Contracts\Core\Repository\Values\Content\Search\AggregationResult\TermAggregationResultEntry but does not specify its types: TKey
Error: Method Ibexa\Bundle\Search\Twig\Extension\SearchFacetsExtension::getChoicesAsFacets() has parameter $terms with generic class Ibexa\Contracts\Core\Repository\Values\Content\Search\AggregationResult\TermAggregationResult but does not specify its types: TKey
Error: Method Ibexa\Bundle\Search\Twig\Extension\SearchFacetsExtension::findTermEntry() has parameter $comparator with generic class Ibexa\Contracts\Core\Repository\Values\Content\Search\AggregationResult\TermAggregationResultEntry but does not specify its types: TKey
Error: Method Ibexa\Bundle\Search\Twig\Extension\SearchFacetsExtension::findTermEntry() has parameter $terms with generic class Ibexa\Contracts\Core\Repository\Values\Content\Search\AggregationResult\TermAggregationResult but does not specify its types: TKey
Error: Method Ibexa\Bundle\Search\Twig\Extension\SearchFacetsExtension::findTermEntry() return type with generic class Ibexa\Contracts\Core\Repository\Values\Content\Search\AggregationResult\TermAggregationResultEntry does not specify its types: TKey
Error: Parameter #1 $data of method Ibexa\Search\Mapper\PagerSearchContentToDataMapper::setTranslatedContentTypesNames() expects array<array{content: Ibexa\Contracts\Core\Repository\Values\Content\Content, contentTypeId: int, contentId: int, name: string, language: string, contributor: Ibexa\Contracts\Core\Repository\Values\User\User|null, version: int, content_type: Ibexa\Contracts\Core\Repository\Values\ContentType\ContentType, ...}>, list<array{content: Ibexa\Contracts\Core\Repository\Values\Content\Content, contentTypeId: int, contentId: int, mainLocationId: int|null, name: string, language: string, contributor: Ibexa\Contracts\Core\Repository\Values\User\User|null, version: int, ...}> given.
Error: Ignored error pattern #^Property Ibexa\\Contracts\\Core\\Repository\\Values\\Content\\Search\\SearchHit\<Ibexa\\Contracts\\Core\\Repository\\Values\\ValueObject\>\:\:\$score \(float\) on left side of \?\? is not nullable\.$# (nullCoalesce.property) in path /home/runner/work/search/search/src/lib/Mapper/SearchHitToContentSuggestionMapper.php was not matched in reported errors.
 ------ ---------------------------------------------------------------------------------------------------- 
  Line   src/bundle/Form/ChoiceList/View/FacetView.php                                                       
 ------ ---------------------------------------------------------------------------------------------------- 
  16     Property Ibexa\Bundle\Search\Form\ChoiceList\View\FacetView::$term                                  
         with generic class                                                                                  
         Ibexa\Contracts\Core\Repository\Values\Content\Search\AggregationResult\TermAggregationResultEntry  
         does not specify its types: TKey                                                                    
         🪪 missingType.generics                                                                             
  18     Method                                                                                              
         Ibexa\Bundle\Search\Form\ChoiceList\View\FacetView::createFromChoiceView()                          
         has parameter $term with generic class                                                              
         Ibexa\Contracts\Core\Repository\Values\Content\Search\AggregationResult\TermAggregationResultEntry  
         but does not specify its types: TKey                                                                
         🪪 missingType.generics                                                                             
 ------ ---------------------------------------------------------------------------------------------------- 

 ------ ---------------------------------------------------------------------------------------------------- 
  Line   src/bundle/Twig/Extension/SearchFacetsExtension.php                                                 
 ------ ---------------------------------------------------------------------------------------------------- 
  45     Method                                                                                              
         Ibexa\Bundle\Search\Twig\Extension\SearchFacetsExtension::getChoicesAsFacets()                      
         has parameter $comparator with generic class                                                        
         Ibexa\Contracts\Core\Repository\Values\Content\Search\AggregationResult\TermAggregationResultEntry  
         but does not specify its types: TKey                                                                
         🪪 missingType.generics                                                                             
  45     Method                                                                                              
         Ibexa\Bundle\Search\Twig\Extension\SearchFacetsExtension::getChoicesAsFacets()                      
         has parameter $terms with generic class                                                             
         Ibexa\Contracts\Core\Repository\Values\Content\Search\AggregationResult\TermAggregationResult       
         but does not specify its types: TKey                                                                
         🪪 missingType.generics                                                                             
  91     Method                                                                                              
         Ibexa\Bundle\Search\Twig\Extension\SearchFacetsExtension::findTermEntry()                           
         has parameter $comparator with generic class                                                        
         Ibexa\Contracts\Core\Repository\Values\Content\Search\AggregationResult\TermAggregationResultEntry  
         but does not specify its types: TKey                                                                
         🪪 missingType.generics                                                                             
  91     Method                                                                                              
         Ibexa\Bundle\Search\Twig\Extension\SearchFacetsExtension::findTermEntry()                           
         has parameter $terms with generic class                                                             
         Ibexa\Contracts\Core\Repository\Values\Content\Search\AggregationResult\TermAggregationResult       
         but does not specify its types: TKey                                                                
         🪪 missingType.generics                                                                             
  91     Method                                                                                              
         Ibexa\Bundle\Search\Twig\Extension\SearchFacetsExtension::findTermEntry()                           
         return type with generic class                                                                      
         Ibexa\Contracts\Core\Repository\Values\Content\Search\AggregationResult\TermAggregationResultEntry  
         does not specify its types: TKey                                                                    
         🪪 missingType.generics                                                                             
 ------ ---------------------------------------------------------------------------------------------------- 

 ------ -------------------------------------------------------------------------------------- 
  Line   src/lib/Mapper/PagerSearchContentToDataMapper.php                                     
 ------ -------------------------------------------------------------------------------------- 
  113    Parameter #1 $data of method                                                          
         Ibexa\Search\Mapper\PagerSearchContentToDataMapper::setTranslatedContentTypesNames()  
         expects array<array{content:                                                          
         Ibexa\Contracts\Core\Repository\Values\Content\Content,                               
         contentTypeId: int, contentId: int, name: string, language: string,                   
         contributor: Ibexa\Contracts\Core\Repository\Values\User\User|null,                   
         version: int, content_type:                                                           
         Ibexa\Contracts\Core\Repository\Values\ContentType\ContentType,                       
         ...}>, list<array{content:                                                            
         Ibexa\Contracts\Core\Repository\Values\Content\Content,                               
         contentTypeId: int, contentId: int, mainLocationId: int|null, name:                   
         string, language: string, contributor:                                                
         Ibexa\Contracts\Core\Repository\Values\User\User|null, version: int,                  
         ...}> given.                                                                          
         🪪 argument.type                                                                      
         💡 Offset 'translation_language_code' (string) does not accept type                   
            string|null.                                                                       
 ------ -------------------------------------------------------------------------------------- 

 ------ -------------------------------------------------------------------------------------------------------------------------------------------- 
  Line   src/lib/Mapper/SearchHitToContentSuggestionMapper.php                                                                                       
 ------ -------------------------------------------------------------------------------------------------------------------------------------------- 
         Ignored error pattern #^Property                                                                                                            
         Ibexa\\Contracts\\Core\\Repository\\Values\\Content\\Search\\SearchHit<Ibexa\\Contracts\\Core\\Repository\\Values\\ValueObject>\:\:\$score  
         \(float\) on left side of \?\? is not nullable\.$#                                                                                          
         (nullCoalesce.property) in path                                                                                                             
         /home/runner/work/search/search/src/lib/Mapper/SearchHitToContentSuggestionMapper.php                                                       
         was not matched in reported errors.                                                                                                         
 ------ -------------------------------------------------------------------------------------------------------------------------------------------- 

Error:  [ERROR] Found 9 errors                                                         

Script phpstan analyse handling the phpstan event returned with error code 1
Error: Process completed with exit code 1.
```

Ref. https://github.com/ibexa/search/actions/runs/15946473099/job/44981170296

#### For QA:
N/A

#### Documentation:
N/A


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - For new features, confirm that you have suitable access control and injection prevention
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
