### PR TITLE
[Translations] Fixed translation extraction

### DIFF
--- a/src/bundle/DependencyInjection/IbexaSearchExtension.php
+++ b/src/bundle/DependencyInjection/IbexaSearchExtension.php
@@ -43,7 +43,12 @@ class IbexaSearchExtension extends Extension implements PrependExtensionInterfac
                     ],
                     'output_dir' => __DIR__ . '/../Resources/translations/',
                     'output_format' => 'xliff',
-                    'excluded_names' => ['*.module.js'],
+                    'excluded_names' => [
+                        '*.module.js',
+                        // [Workaround] Skipped due to the bug in symfony/type-info component
+                        'FacetGroupView.php',
+                        'FacetView.php',
+                    ],
                     'excluded_dirs' => [],
                     'extractors' => [],
                 ],

--- a/src/bundle/Twig/Extension/SearchFacetsExtension.php
+++ b/src/bundle/Twig/Extension/SearchFacetsExtension.php
@@ -12,6 +12,7 @@ use Ibexa\Bundle\Search\Form\ChoiceList\View\FacetGroupView;
 use Ibexa\Bundle\Search\Form\ChoiceList\View\FacetView;
 use Ibexa\Contracts\Core\Repository\Values\Content\Search\AggregationResult\TermAggregationResult;
 use Ibexa\Contracts\Core\Repository\Values\Content\Search\AggregationResult\TermAggregationResultEntry;
+use JMS\TranslationBundle\Annotation\Ignore;
 use Symfony\Component\Form\ChoiceList\View\ChoiceGroupView;
 use Symfony\Component\Form\ChoiceList\View\ChoiceView;
 use Symfony\Contracts\Translation\TranslatableInterface;
@@ -76,7 +77,7 @@ final class SearchFacetsExtension extends AbstractExtension
             if ($term !== null) {
                 $label = $choice->label;
                 if ($label instanceof TranslatableInterface) {
-                    $label = $label->trans($this->translator);
+                    $label = /** @Ignore */ $label->trans($this->translator);
                 }
 
                 $facet = FacetView::createFromChoiceView($choice, $term);


### PR DESCRIPTION
| :ticket: Issue | N/A |
|----------------|-----------|

<!-- 
#### Related PRs: 
- https://github.com/ibexa/core/pull/1
-->

#### Description:
```

In StringTypeResolver.php line 88:
                                                               
  [Symfony\Component\TypeInfo\Exception\UnsupportedException]  
  Cannot resolve "array<(ChoiceGroupView | ChoiceView)>".      
                                                               

Exception trace:
  at /home/awojs/ibexa/ibexa-dxp-on-sf73/vendor/symfony/type-info/TypeResolver/StringTypeResolver.php:88
 Symfony\Component\TypeInfo\TypeResolver\StringTypeResolver->resolve() at /home/awojs/ibexa/ibexa-dxp-on-sf73/vendor/symfony/property-info/Extractor/PhpStanExtractor.php:254
 Symfony\Component\PropertyInfo\Extractor\PhpStanExtractor->getTypeFromConstructor() at /home/awojs/ibexa/ibexa-dxp-on-sf73/vendor/symfony/property-info/Extractor/ConstructorExtractor.php:35
 Symfony\Component\PropertyInfo\Extractor\ConstructorExtractor->getType() at /home/awojs/ibexa/ibexa-dxp-on-sf73/vendor/symfony/property-info/PropertyInfoExtractor.php:70
 Symfony\Component\PropertyInfo\PropertyInfoExtractor->getType() at /home/awojs/ibexa/ibexa-dxp-on-sf73/vendor/symfony/validator/Mapping/Loader/PropertyInfoLoader.php:193
 Symfony\Component\Validator\Mapping\Loader\PropertyInfoLoader->getPropertyTypes() at /home/awojs/ibexa/ibexa-dxp-on-sf73/vendor/symfony/validator/Mapping/Loader/PropertyInfoLoader.php:70
 Symfony\Component\Validator\Mapping\Loader\PropertyInfoLoader->loadClassMetadata() at /home/awojs/ibexa/ibexa-dxp-on-sf73/vendor/symfony/validator/Mapping/Loader/LoaderChain.php:48
 Symfony\Component\Validator\Mapping\Loader\LoaderChain->loadClassMetadata() at /home/awojs/ibexa/ibexa-dxp-on-sf73/vendor/symfony/validator/Mapping/Factory/LazyLoadingMetadataFactory.php:96
 Symfony\Component\Validator\Mapping\Factory\LazyLoadingMetadataFactory->getMetadataFor() at /home/awojs/ibexa/ibexa-dxp-on-sf73/vendor/symfony/validator/Validator/RecursiveValidator.php:70
 Symfony\Component\Validator\Validator\RecursiveValidator->getMetadataFor() at /home/awojs/ibexa/ibexa-dxp-on-sf73/vendor/ibexa/core/src/contracts/Validation/StructWrapperValidator.php:31
 Ibexa\Contracts\Core\Validation\StructWrapperValidator->getMetadataFor() at /home/awojs/ibexa/ibexa-dxp-on-sf73/vendor/jms/translation-bundle/Translation/Extractor/File/ValidationExtractor.php:87                                                                                                                                                                                                  
 JMS\TranslationBundle\Translation\Extractor\File\ValidationExtractor->enterNode() at /home/awojs/ibexa/ibexa-dxp-on-sf73/vendor/nikic/php-parser/lib/PhpParser/NodeTraverser.php:196
 PhpParser\NodeTraverser->traverseArray() at /home/awojs/ibexa/ibexa-dxp-on-sf73/vendor/nikic/php-parser/lib/PhpParser/NodeTraverser.php:98
 PhpParser\NodeTraverser->traverseNode() at /home/awojs/ibexa/ibexa-dxp-on-sf73/vendor/nikic/php-parser/lib/PhpParser/NodeTraverser.php:227
 PhpParser\NodeTraverser->traverseArray() at /home/awojs/ibexa/ibexa-dxp-on-sf73/vendor/nikic/php-parser/lib/PhpParser/NodeTraverser.php:76
 PhpParser\NodeTraverser->traverse() at /home/awojs/ibexa/ibexa-dxp-on-sf73/vendor/jms/translation-bundle/Translation/Extractor/File/ValidationExtractor.php:109
 JMS\TranslationBundle\Translation\Extractor\File\ValidationExtractor->visitPhpFile() at n/a:n/a
 call_user_func_array() at /home/awojs/ibexa/ibexa-dxp-on-sf73/vendor/jms/translation-bundle/Translation/Extractor/FileExtractor.php:216
 JMS\TranslationBundle\Translation\Extractor\FileExtractor->extract() at /home/awojs/ibexa/ibexa-dxp-on-sf73/vendor/jms/translation-bundle/Translation/ExtractorManager.php:138
 JMS\TranslationBundle\Translation\ExtractorManager->extract() at /home/awojs/ibexa/ibexa-dxp-on-sf73/vendor/jms/translation-bundle/Translation/Updater.php:259
 JMS\TranslationBundle\Translation\Updater->setConfig() at /home/awojs/ibexa/ibexa-dxp-on-sf73/vendor/jms/translation-bundle/Translation/Updater.php:136
 JMS\TranslationBundle\Translation\Updater->process() at /home/awojs/ibexa/ibexa-dxp-on-sf73/vendor/jms/translation-bundle/Command/ExtractTranslationCommand.php:139
 JMS\TranslationBundle\Command\ExtractTranslationCommand->execute() at /home/awojs/ibexa/ibexa-dxp-on-sf73/vendor/symfony/console/Command/Command.php:318
 Symfony\Component\Console\Command\Command->run() at /home/awojs/ibexa/ibexa-dxp-on-sf73/vendor/symfony/console/Application.php:1092
 Symfony\Component\Console\Application->doRunCommand() at /home/awojs/ibexa/ibexa-dxp-on-sf73/vendor/symfony/framework-bundle/Console/Application.php:123
 Symfony\Bundle\FrameworkBundle\Console\Application->doRunCommand() at /home/awojs/ibexa/ibexa-dxp-on-sf73/vendor/symfony/console/Application.php:341
 Symfony\Component\Console\Application->doRun() at /home/awojs/ibexa/ibexa-dxp-on-sf73/vendor/symfony/framework-bundle/Console/Application.php:77
 Symfony\Bundle\FrameworkBundle\Console\Application->doRun() at /home/awojs/ibexa/ibexa-dxp-on-sf73/vendor/symfony/console/Application.php:192
 Symfony\Component\Console\Application->run() at /home/awojs/ibexa/ibexa-dxp-on-sf73/vendor/symfony/runtime/Runner/Symfony/ConsoleApplicationRunner.php:49
 Symfony\Component\Runtime\Runner\Symfony\ConsoleApplicationRunner->run() at /home/awojs/ibexa/ibexa-dxp-on-sf73/vendor/autoload_runtime.php:29
 require_once() at /home/awojs/ibexa/ibexa-dxp-on-sf73/bin/console:15
```


#### For QA:
N/A

#### Documentation:
N/A


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - For new features, confirm that you have suitable access control and injection prevention
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
