### PR TITLE
Allow Pagerfanta 4.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": " >=8.3",
         "ibexa/core": "~5.0.x-dev",
-        "pagerfanta/pagerfanta": "^3.6.2",
+        "pagerfanta/pagerfanta": "^3.6.2 || ^4.7",
         "symfony/config": "^7.3",
         "symfony/dependency-injection": "^7.3",
         "symfony/event-dispatcher": "^7.3",


### PR DESCRIPTION
| :ticket: Issue | IBX-XXXXX |
|----------------|-----------|

#### Related PRs: 
- https://github.com/ibexa/core/pull/694

#### Description:
This allows using Pagerfanta 4.x. There shouldn't be any breaking changes between 3.x and 4.x